### PR TITLE
Add activation events for commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,15 @@
         ]
     },
     "activationEvents": [
-        "onLanguage:v"
+        "onLanguage:v",
+        "onCommand:v.run",
+        "onCommand:v.prod",
+        "onCommand:v.help",
+        "onCommand:v.ver",
+        "onCommand:v.path",
+        "onCommand:v.test.file",
+        "onCommand:v.test.package",
+        "onCommand:v.playground"
     ],
     "main": "./out/extension.js",
     "dependencies": {


### PR DESCRIPTION
Previously, the commands were not recognized when no V file was opened. Now the extension starts when a command is run.

For commands like `v.run` that require a V file to be open, a better solution might be to hide the command when no V file is open, but I couldn't get that to work.