### PR TITLE
Fixes #13: Do not ignore out directory in extension build

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,6 +1,5 @@
 .vscode/**
 .vscode-test/**
-out/**
 node_modules/fs-extra/**
 .gitignore
 .tmp


### PR DESCRIPTION
Fixes #13 

If you want to ship the executable extension code in the "out" directory then it's important that the files in this directory shouldn't be ignored in the vsce package.