### PR TITLE
tsconfig: remove `lib` option

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,9 +3,6 @@
         "module": "commonjs",
         "target": "es6",
         "outDir": "out",
-        "lib": [
-            "es6"
-        ],
         "sourceMap": true
     },
     "exclude": [


### PR DESCRIPTION
Remove the `lib` option. Because it is not needed in the latest TSC version.