### PR TITLE
snippets: capitalize struct name

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -195,7 +195,7 @@
 		"prefix": "stru",
 		"scope": "v,vlang",
 		"body": [
-			"struct ${1:name} {",
+			"struct ${1:Name} {",
 			"\t$0",
 			"}"
 		],


### PR DESCRIPTION
The name of the struct in V must be capitalized.