### PR TITLE
Fix attribute highlighting and adjust comment scopes

### DIFF
--- a/syntaxes/v.tmLanguage.json
+++ b/syntaxes/v.tmLanguage.json
@@ -95,6 +95,9 @@
 			"include": "#comments"
 		},
 		{
+			"include": "#attributes"
+		},
+		{
 			"include": "#brackets"
 		},
 		{
@@ -197,21 +200,37 @@
 			"patterns": [
 				{
 					"comment": "Before function definition",
-					"name": "meta.function.attribute.v",
-					"match": "^\\s*(?=\\[(live|inline)\\])",
+					"match": "^\\s*((\\[)(live|inline)(\\]))",
 					"captures": {
 						"1": {
-							"name": "entity.function.attribute.v"
+							"name": "meta.function.attribute.v"
+						},
+						"2": {
+							"name": "punctuation.definition.begin.bracket.square.v"
+						},
+						"3": {
+							"name": "storage.modifier.attribute.v"
+						},
+						"4": {
+							"name": "punctuation.definition.end.bracket.square.v"
 						}
 					}
 				},
 				{
 					"comment": "After struct literals",
-					"name": "meta.struct.attribute.v",
-					"match": "(?<=[0-9a-zA-Z_\\s])(?=\\[(skip)\\])",
+					"match": "(?<=[0-9a-zA-Z_\\s])((\\[)(skip)(\\]))",
 					"captures": {
+						"0": {
+							"name": "meta.struct.attribute.v"
+						},
 						"1": {
+							"name": "punctuation.definition.begin.bracket.square.v"
+						},
+						"2": {
 							"name": "entity.struct.attribute.v"
+						},
+						"3": {
+							"name": "punctuation.definition.end.bracket.square.v"
 						}
 					}
 				}

--- a/syntaxes/v.tmLanguage.json
+++ b/syntaxes/v.tmLanguage.json
@@ -415,24 +415,29 @@
 			"patterns": [
 				{
 					"begin": "/\\*",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.comment.begin.v"
+						}
+					},
 					"end": "\\*/",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.comment.end.v"
+						}
+					},
 					"patterns": [
 						{
 							"include":"#comments"
 						}
 					],
-					"captures": {
-						"0": {
-							"name": "comment.block.documentation.v"
-						}
-					},
-					"name": "comment.block.v"
+					"name": "comment.block.documentation.v"
 				},
 				{
 					"begin": "//",
 					"beginCaptures": {
 						"0": {
-							"name": "comment.block.documentation.v"
+							"name": "punctuation.definition.comment.begin.v"
 						}
 					},
 					"end": "$",


### PR DESCRIPTION
Two meagre adjustments, nothing exciting:

1.	`[live]` attributes aren't being tokenised, so I fixed them:
	~~~v
	[live] 
	fn (ctx &Context) draw() {
		ctx.gg.draw_line(0, Size / 2, Size, Size / 2) // x axis 
		ctx.gg.draw_line(Size / 2, 0, Size / 2, Size) // y axis 
	}
	~~~

2.	Comments are now tokenised correctly.