### PR TITLE
Add missing comma to list of fileTypes

### DIFF
--- a/syntaxes/v.tmLanguage.json
+++ b/syntaxes/v.tmLanguage.json
@@ -3,7 +3,7 @@
 	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
 	"fileTypes": [
 		".v",
-		".vh"
+		".vh",
 		".vsh"
 	],
 	"scopeName": "source.v",


### PR DESCRIPTION
👋 I'm the lead maintainer of https://github.com/github/linguist which uses this grammar for syntax highlighting of V files on GitHub.com.

I'm in the process of making a new release and our grammar compiler has detected an error in your grammar that was introduced in https://github.com/0x9ef/vscode-vlang/pull/29:

```
Grammar conversion failed. File `syntaxes/v.tmLanguage.json` failed to parse: invalid character '"' after array element
```

The error is caused by a missing comma in the list of `fileTypes`. This PR addresses that by adding in the missing comma.

With this comma in place, our grammar compiler succeeds without any errors as it did before https://github.com/0x9ef/vscode-vlang/pull/29.