### PR TITLE
Ignore VSIX packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .vscode/ipch
-test.v
-testDpm.v
 node_modules
 out
+test.v
+testDpm.v
+*.vsix


### PR DESCRIPTION
As this repository does not contains binary packages, it's better to ignore them.