### PR TITLE
Add support for `as` keyword

### DIFF
--- a/syntaxes/v.tmLanguage.json
+++ b/syntaxes/v.tmLanguage.json
@@ -35,6 +35,21 @@
       }
     },
     {
+      "name": "meta.definition.as.v",
+      "begin": "\\s+(as)\\s+",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.as.v"
+        }
+      },
+      "end": "([0-9a-zA-Z_.]*)",
+      "endCaptures": {
+        "1": {
+          "name": "entity.name.alias.v"
+        }
+      }
+    },
+    {
       "name": "meta.definition.include.v",
       "begin": "^\\s*(#include)",
       "beginCaptures": {
@@ -81,7 +96,7 @@
     },
     {
       "name": "meta.definition.escaped.keyword.v",
-      "match": "((?:@)(?:mut|pub|fn|module|import|const|map|assert|sizeof|type|struct|interface|enum|in|or|match|if|else|for|go|goto|defer|return|i?(?:8|16|nt|64|128)|u?(?:16|32|64|128)|f?(?:32|64)|bool|byte|byteptr|charptr|voidptr|string|ustring|rune|none))",
+      "match": "((?:@)(?:mut|pub|fn|module|import|as|const|map|assert|sizeof|type|struct|interface|enum|in|or|match|if|else|for|go|goto|defer|return|i?(?:8|16|nt|64|128)|u?(?:16|32|64|128)|f?(?:32|64)|bool|byte|byteptr|charptr|voidptr|string|ustring|rune|none))",
       "captures": {
         "0": {
           "name": "keyword.other.escaped.v"


### PR DESCRIPTION
### Desciption

This keyword is used to apply aliases to imported packages.

### Screenshot

![image](https://user-images.githubusercontent.com/1119267/71488761-4be58e80-2833-11ea-8fe4-e518dc018d0a.png)

