### PR TITLE
Remove unused entries from `.travis.yml`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,5 @@ cache: npm
 install:
   - npm install
 
-before_script:
-  - npm install -g typescript@1.0
-
 script:
   - npm run compile
-  - tsc -p ./


### PR DESCRIPTION
`tsc -p ./` is a duplicate of `npm run compile` which runs the same command.
`npm install -g typescript@1.0` is unused, as `typescript` is installed via `npm install`.

~~The PR based on caa79e6 to prove it still works; it should be mergeable, though.~~ For some reason Travis CI pulls sources from master.

As an alternative solution I can create a workflow for GitHub Actions instead of using Travis CI.