### PR TITLE
Fix inconsistent `struct` highlighting

### DIFF
--- a/syntaxes/v.tmLanguage.json
+++ b/syntaxes/v.tmLanguage.json
@@ -1,5 +1,5 @@
 {
-	"name": "v",
+	"name": "V",
 	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
 	"fileTypes": [".v", ".vh", ".vsh"],
 	"scopeName": "source.v",

--- a/syntaxes/v.tmLanguage.json
+++ b/syntaxes/v.tmLanguage.json
@@ -901,28 +901,102 @@
 		"struct": {
 			"patterns": [
 				{
-					"comment": "Structure",
 					"name": "meta.definition.struct.v",
-					"match": "^\\s*(\\bstruct\\b)\\s+(?:[0-9a-zA-Z_]+\\.)?([0-9a-zA-Z_]*)",
-					"captures": {
+					"begin": "\\s*(?:(mut|pub(?:\\s+mut)?|__global)\\s+)?(struct)\\s+([0-9a-zA-Z_.]+)\\s*({)",
+					"beginCaptures": {
 						"1": {
-							"name": "keyword.struct.v"
+							"name": "storage.modifier.$1.v"
 						},
 						"2": {
-							"patterns": [
-								{
-									"name": "invalid.illegal.v",
-									"match": "\\d\\w+"
+							"name": "storage.type.struct.v"
+						},
+						"3": {
+							"name": "entity.name.struct.v"
+						},
+						"4": {
+							"name": "punctuation.definition.bracket.curly.begin.v"
+						}
+					},
+					"end": "\\s*(})",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.bracket.curly.end.v"
+						}
+					},
+					"patterns": [
+						{
+							"include": "#struct-access-modifier"
+						},
+						{
+							"match": "\\b(\\w+)\\s+(\\w+)(?:\\s*(=)\\s*((?:.(?=$|//|/\\*))*+))?",
+							"captures": {
+								"1": {
+									"name": "variable.other.property.v"
 								},
-								{
-									"name": "entity.name.struct.v",
-									"match": "\\w+"
+								"2": {
+									"patterns": [
+										{
+											"include": "#std-types"
+										},
+										{
+											"include": "#std-cbased-types"
+										},
+										{
+											"match": "\\w+",
+											"name": "storage.type.other.v"
+										}
+									]
+								},
+								"3": {
+									"name": "keyword.operator.assignment.v"
+								},
+								"4": {
+									"patterns": [
+										{
+											"include": "$self"
+										}
+									]
 								}
-							]
+							}
+						},
+						{
+							"include": "#std-types"
+						},
+						{
+							"include": "#std-cbased-types"
+						},
+						{
+							"include": "$self"
+						}
+					]
+				},
+				{
+					"name": "meta.definition.struct.v",
+					"match": "(?:(mut|pub(?:\\s+mut)?|__global)\\s+)?(struct)(?:\\s+([0-9a-zA-Z_.]+))?",
+					"captures": {
+						"1": {
+							"name": "storage.modifier.$1.v"
+						},
+						"2": {
+							"name": "storage.type.struct.v"
+						},
+						"3": {
+							"name": "entity.name.struct.v"
 						}
 					}
 				}
 			]
+		},
+		"struct-access-modifier": {
+			"match": "(?<=\\s|^)(mut|pub(?:\\s+mut)?|__global)(:|\\b)",
+			"captures": {
+				"1": {
+					"name": "storage.modifier.$1.v"
+				},
+				"2": {
+					"name": "punctuation.separator.struct.key-value.v"
+				}
+			}
 		},
 		"interface": {
 			"patterns": [
@@ -1059,11 +1133,6 @@
 					"comment": "Keyword Based Enumeration",
 					"name": "keyword.enum.v",
 					"match": "\\benum\\b"
-				},
-				{
-					"comment": "Keyword Based Structure",
-					"name": "keyword.struct.v",
-					"match": "\\bstruct\\b"
 				},
 				{
 					"comment": "Keyword Based Interface",


### PR DESCRIPTION
Solves #56 and #55:

~~~v
pub struct Foo {
	a int = 2
	a int     // private immutable (default)
mut:
	b int     // private mutable
	c int     // (you can list multiple fields with the same access modifier) 
pub:
	d int     // public immmutable (readonly)
pub mut:
	e int     // public, but mutable only in parent module 
__global:
	f int 	  // public and mutable both inside and outside parent module 
}
~~~

[Go here for a preview](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_format=json&grammar_url=https%3A%2F%2Fgithub.com%2FCutlery-Drawer%2Fvscode-vlang%2Fblob%2F2118c9e4187fe6045cde4808e834ed3e50a68952%2Fsyntaxes%2Fv.tmLanguage.json&grammar_text=&code_source=from-text&code_url=&code=pub+struct+Foo+%7B%0D%0A%09a+int+%3D+2%0D%0A%09a+int+++++%2F%2F+private+immutable+%28default%29%0D%0Amut%3A%0D%0A%09b+int+++++%2F%2F+private+mutable%0D%0A%09c+int+++++%2F%2F+%28you+can+list+multiple+fields+with+the+same+access+modifier%29+%0D%0Apub%3A%0D%0A%09d+int+++++%2F%2F+public+immmutable+%28readonly%29%0D%0Apub+mut%3A%0D%0A%09e+int+++++%2F%2F+public%2C+but+mutable+only+in+parent+module+%0D%0A__global%3A%0D%0A%09f+int+%09++%2F%2F+public+and+mutable+both+inside+and+outside+parent+module+%0D%0A%7D).