### PR TITLE
Fix Markdown issues

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,4 @@
+{
+    "MD013": false,
+    "MD024": false
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,11 @@ cache: npm
 
 install:
   - npm install
+  - npm install -g markdownlint-cli
 
-script:
-  - npm run compile
+jobs:
+  include:
+    - stage: Compilation
+      script: npm run compile
+    - stage: Markdown Linting
+      script: markdownlint *.md

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,10 @@ cache: npm
 
 install:
   - npm install
-  - npm install -g markdownlint-cli
 
 jobs:
   include:
     - stage: Compilation
       script: npm run compile
     - stage: Markdown Linting
-      script: markdownlint *.md
+      script: npm run lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -7,7 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [0.0.1] - 2019-06-10
+
 ### Added
+
 - Code snippets for standart keywords and expressions.
 - Developer dark theme for **V**.
 - TextMate Language Support for **V**.
@@ -15,42 +18,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Images in `/images` folder.
 - Icon theme in `/theme/icon-theme.json`.
 - Icon for `.v` based files in `theme/images/v.svg`.
+
 ### Changed
+
 ### Removed
 
 ## [0.0.2] - 2019-06-12
+
 ### Added
+
 - Pattern for new-function variables, punctuation characters.
 - Pattern for exist-function punctuation characters.
 - Pattern for arithmethic, relation, logical, bitwise, assignment operators.
+
 ### Fixed
+
 - Invalid patterns for assignment operator. 
-- Invalid patterns for integer, float, hex numerics. 
+- Invalid patterns for integer, float, hex numerics.
 - Invalid patterns for new/exist function arguments.
+
 ### Changed
+
 - Highligting for `module, import, struct, enum, interface` from `default` to `bold underline`.
+
 ### Removed
 
 ## [0.0.3] - 2019-06-16
+
 ### Added
+
 - Pattern for generics.
 - Generic highlighting.
 - Assignment operators `&=, |=, ^=, &&=, ||=, >>=, <<=`.
+
 ### Fixed
-- Invalid pattern for float numeric. 
-- Invalid pattern for new/exist function. 
+
+- Invalid pattern for float numeric.
+- Invalid pattern for new/exist function.
+
 ### Changed
+
 ### Removed
 
 ## [0.0.4] - 2019-06-22
+
 ### Added
+
 - Pattern for static types `byteptr, voidptr, ustring`
 - Pattern for extend (extra) function syntax `fn (a mut Vector) Set() {}`
 - Pattern for limited operator overloading `fn (a Operand) + (b Operand)Operand {}`
 - String placeholder.
 - String escaped characters.
 - Highlighting for V compiler headers without open source code __`.vh`__
+
 ### Fixed
+
 - Invalid pattern for floating point numbers.
 - Invalid pattern for single, double strings. 
 - Invalid pattern for new function declaration.
@@ -59,11 +81,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Invalid pattern for generic `<T>`
 - Invalid pattern for variable assignment.
 - Invalid pattern for label (conflict with default keyword) __`default:`__
+
 ### Changed
+
 - Included pattern for variable increment, decrement.  
 
 ## [0.0.5] - 2019-06-05
-### Added 
+
+### Added
+
 - Pattern for static type `intptr`
 - Pattern for control keyword `$else`
 - Pattern for builtin casting/control function ([f877c3b](https://github.com/0x9ef/vscode-vlang/commit/f877c3b844564125431f9bd4accda0b4924f5f6c)).
@@ -73,7 +99,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added two commands `v.ver, v.prod` ([d1d99a9](https://github.com/0x9ef/vscode-vlang/commit/d1d99a9806f9ffbbe235974f153fa837f2eb6b3b))
 - Added TypeScript based project ([9fa4992](https://github.com/0x9ef/vscode-vlang/commit/9fa4992a7f549351c97d17b1ff95c94970e74bb3))
 - Created `package-lock.json` ([16114d6](https://github.com/0x9ef/vscode-vlang/commit/16114d69ece533c217a0153655a2796c717fd02c))
+
 ### Fixed
+
 - Invalid pattern for new-exist-extend-limited-overloaded functions ([8952a71](https://github.com/0x9ef/vscode-vlang/commit/8952a717ecd2683cfc69caca52f232a5540cd2b5))
 - Invalid pattern for `module, import, #include`
 - Invalid pattern for `enum, type, struct, interface` ([83e27e0](https://github.com/0x9ef/vscode-vlang/commit/83e27e0e64a4a51414ec8ed80dbc6f03fb8bb517))
@@ -81,55 +109,73 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Invalid pattern for variable assignment.
 
 ## [0.0.6] - 2019-07-15
+
 ### Added
+
 - Metadata properties [37dd64b](https://github.com/0x9ef/vscode-vlang/commit/37dd64bcaf1a7799260d29773f55bf23f5f28247)
 - Ignore for specify files [45fbdd9](https://github.com/0x9ef/vscode-vlang/commit/45fbdd952a7c8dc6e971f52388b9629c9fd6ba4e)
 - Pattern for reference [b495745](https://github.com/0x9ef/vscode-vlang/commit/b495745e4354aee7d609adef164fc48be3a75d7e)
+
 ### Fixed
+
 - Invalid pattern for `ustring` [f7f32d1](https://github.com/0x9ef/vscode-vlang/commit/f7f32d108f2aa031b8335073ef77ab774a77f284)
 - Travis support [d1931ed](https://github.com/0x9ef/vscode-vlang/commit/d1931ed55b42161f6bd1df023685c1d060471165)
 - Invalid pattern for `variable-assignment` [c2ad846](https://github.com/0x9ef/vscode-vlang/commit/c2ad846e79aed3e5c4add8ee2e48aa3d20f18607)
 - `#include` pattern [ecf50c0](https://github.com/0x9ef/vscode-vlang/commit/ecf50c0a830923090b6f13700e8baca9bc3c3c86)
+
 ### Changed
+
 - types/vscode version to 1.20.0 [37dd64b](https://github.com/0x9ef/vscode-vlang/commit/37dd64bcaf1a7799260d29773f55bf23f5f28247)
+
 ### Removed
+
 - Autoclosed multilines comments (block) [012e640](https://github.com/0x9ef/vscode-vlang/commit/012e640a84772162a7d822c3b87890c20244fa78)
 
-# [0.0.7] - 2019-08-12
+## [0.0.7] - 2019-08-12
+
 ### Added
+
 - New demos [636c358](https://github.com/0x9ef/vscode-vlang/commit/636c358eb53104f0b3f42f214305f9ef10fb9599)
 - New badges [ab94ea7](https://github.com/0x9ef/vscode-vlang/commit/ab94ea75950a59a5832cb6a6f32e6e8d5197e63a)
 
 ### Changed
+
 - Fixed function declaration from new line [cede5204](https://github.com/0x9ef/vscode-vlang/commit/cede52044e7acd56f880b0729dc3280c16d4c3e9)
 - Fixed invalid function space pattern [88477c2](https://github.com/0x9ef/vscode-vlang/commit/88477c24709836dd8e7d5fdd01d0f729870c278b)
 - Fixed import, module (s) bag [ef56b2c](https://github.com/0x9ef/vscode-vlang/commit/ef56b2c8020d7b6d4d5408635339fa29265ad216)
 
 ### Removed
+
 - Old demos [636c358](https://github.com/0x9ef/vscode-vlang/commit/636c358eb53104f0b3f42f214305f9ef10fb9599)
 - testv.tmLanguage.json [4e3a353](https://github.com/0x9ef/vscode-vlang/commit/4e3a35358d7927efbd47b25911b50e9ad3ee1cd2)
 - Themes for prefering used defined themes [ef56b2c](https://github.com/0x9ef/vscode-vlang/commit/ef56b2c8020d7b6d4d5408635339fa29265ad216)
 
-# [0.0.8] - 2019-10-20
+## [0.0.8] - 2019-10-20
+
 ### Added
+
 - Highlighting for attributes. [f85aec5](https://github.com/0x9ef/vscode-vlang/commit/f85aec57a46116204c9f3fbe370277907ff00a9c)
 - Highlighting for `${...}` syntax [f11581d](https://github.com/0x9ef/vscode-vlang/commit/f11581dcaaadb88da2130a4d9b444d4281f1c0d4)
 - Highlighting for `none` keyword. [d682dbe](https://github.com/0x9ef/vscode-vlang/commit/d682dbefb6330b9383d849334da7677d6f6cf2d6)
 
-### Changed 
+### Changed
+
 - Fixed nested comments. [f19d486](https://github.com/0x9ef/vscode-vlang/commit/f19d4868dd34a729bee01441eb62c6a59a16a1e6)
 - Insert tabs instead of spaces. [f4525ca](https://github.com/0x9ef/vscode-vlang/commit/f4525ca1eb3d514eeb2bb2956724dc18a2645235)
 - Corrupted icon. [beeb022](https://github.com/0x9ef/vscode-vlang/commit/beeb0223c03a1a40b976ef350d546282b3cfa8ff)
 - Infinity recursion in certain grammar patterns [a40e951](https://github.com/0x9ef/vscode-vlang/commit/1638585f838e30c2587eaf9ee8a08c28785b6f42)
 
-# [0.0.9] - 2019-12-30
+## [0.0.9] - 2019-12-30
+
 ### Added
+
 - Highlighting for `as` keyword [e7c72b2](https://github.com/0x9ef/vscode-vlang/commit/e7c72b2cb23444d5c1fa5e5aa2f61e64eaa8264f)
 - Highlighting for `charptr` keyword [b9f16bc](https://github.com/0x9ef/vscode-vlang/commit/b9f16bce1e8089d0b2b2dd50bf09ff8aec621122)
 - Support for `.vsh` [e79a22e](https://github.com/0x9ef/vscode-vlang/commit/e79a22e72dabeca2cc26e08829e6da6f1a957e3c)
 - Some more snippets [b06ae81](https://github.com/0x9ef/vscode-vlang/commit/b06ae81b47ec6354ef1ed887ce6357ef03cd712c)
 
 ### Changed
+
 - Fixed invalid icon theme [be3fcb3](https://github.com/0x9ef/vscode-vlang/commit/be3fcb399a309d52e8869f6ac9067aa454dd3b8a)
 - Fixed `vfmt` [3522196](https://github.com/0x9ef/vscode-vlang/commit/3522196890c4f89da2f173684fe326e79fbb4c52)
 - Cleaned up resource usage [4f587ed](https://github.com/0x9ef/vscode-vlang/commit/4f587ed1cbcd6e884da250528ba7f2e0728127cb)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Invalid patterns for assignment operator. 
+- Invalid patterns for assignment operator.
 - Invalid patterns for integer, float, hex numerics.
 - Invalid patterns for new/exist function arguments.
 
@@ -74,7 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Invalid pattern for floating point numbers.
-- Invalid pattern for single, double strings. 
+- Invalid pattern for single, double strings.
 - Invalid pattern for new function declaration.
 - Invalid pattern for exist function.
 - Invalid patterns for `module, import, #include, #flag`

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 [![Build Status](https://travis-ci.org/0x9ef/vscode-vlang.svg?branch=master)](https://travis-ci.org/0x9ef/vscode-vlang)
 
 [**V Language**](https://vlang.io) support extension for Visual Studio Code. Syntax highlighting and code snippets.
-https://marketplace.visualstudio.com/items?itemName=0x9ef.vscode-vlang&ssr=false
+
+<https://marketplace.visualstudio.com/items?itemName=0x9ef.vscode-vlang&ssr=false>
 
 ## Features
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,8 @@
 		"@types/node": {
 			"version": "13.1.1",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.1.tgz",
-			"integrity": "sha512-hx6zWtudh3Arsbl3cXay+JnkvVgCKzCWKv42C9J01N2T2np4h8w5X8u6Tpz5mj38kE3M9FM0Pazx8vKFFMnjLQ=="
+			"integrity": "sha512-hx6zWtudh3Arsbl3cXay+JnkvVgCKzCWKv42C9J01N2T2np4h8w5X8u6Tpz5mj38kE3M9FM0Pazx8vKFFMnjLQ==",
+			"dev": true
 		},
 		"@types/vscode": {
 			"version": "1.20.0",
@@ -15,15 +16,286 @@
 			"integrity": "sha512-IeQ4kCfbRihpoeSWmC09bGjgdKXB5g09wWdPQcc2WHYjbpsf7p5U1F0bymEMKkyqnledI0LfMTgopwPwnrjTSg==",
 			"dev": true
 		},
+		"argparse": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
+			"requires": {
+				"sprintf-js": "~1.0.2"
+			}
+		},
+		"balanced-match": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
+		},
+		"brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"requires": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"commander": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+			"integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+			"dev": true,
+			"requires": {
+				"graceful-readlink": ">= 1.0.0"
+			}
+		},
+		"concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
+		},
+		"deep-extend": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
+			"integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
+			"dev": true
+		},
+		"entities": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
+			"integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==",
+			"dev": true
+		},
+		"esprima": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"dev": true
+		},
+		"fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
+		},
+		"get-stdin": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz",
+			"integrity": "sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=",
+			"dev": true
+		},
+		"glob": {
+			"version": "7.1.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+			"dev": true,
+			"requires": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			}
+		},
+		"graceful-readlink": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+			"integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+			"dev": true
+		},
+		"inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
+			"requires": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true
+		},
+		"ini": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+			"dev": true
+		},
+		"js-yaml": {
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+			"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+			"dev": true,
+			"requires": {
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
+			}
+		},
+		"jsonc-parser": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.2.0.tgz",
+			"integrity": "sha512-4fLQxW1j/5fWj6p78vAlAafoCKtuBm6ghv+Ij5W2DrDx0qE+ZdEl2c6Ko1mgJNF5ftX1iEWQQ4Ap7+3GlhjkOA==",
+			"dev": true
+		},
+		"linkify-it": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
+			"integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+			"dev": true,
+			"requires": {
+				"uc.micro": "^1.0.1"
+			}
+		},
+		"lodash.differencewith": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.differencewith/-/lodash.differencewith-4.5.0.tgz",
+			"integrity": "sha1-uvr7yRi1UVTheRdqALsK76rIVLc=",
+			"dev": true
+		},
+		"lodash.flatten": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+			"integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
+			"dev": true
+		},
+		"markdown-it": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
+			"integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
+			"dev": true,
+			"requires": {
+				"argparse": "^1.0.7",
+				"entities": "~2.0.0",
+				"linkify-it": "^2.0.0",
+				"mdurl": "^1.0.1",
+				"uc.micro": "^1.0.5"
+			}
+		},
+		"markdownlint": {
+			"version": "0.18.0",
+			"resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.18.0.tgz",
+			"integrity": "sha512-nQAfK9Pbq0ZRoMC/abNGterEnV3kL8MZmi0WHhw8WJKoIbsm3cXGufGsxzCRvjW15cxe74KWcxRSKqwplS26Bw==",
+			"dev": true,
+			"requires": {
+				"markdown-it": "10.0.0"
+			}
+		},
+		"markdownlint-cli": {
+			"version": "0.20.0",
+			"resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.20.0.tgz",
+			"integrity": "sha512-5VCGS+9w/mVMVDHrKOciq+ZXYdFEypyuCvCdNjHdji8itqcryWMr7V2NdpxQ/KeJmMNoRYsdc2R+88lSc+2gpA==",
+			"dev": true,
+			"requires": {
+				"commander": "~2.9.0",
+				"deep-extend": "~0.5.1",
+				"get-stdin": "~5.0.1",
+				"glob": "~7.1.2",
+				"js-yaml": "~3.13.1",
+				"jsonc-parser": "~2.2.0",
+				"lodash.differencewith": "~4.5.0",
+				"lodash.flatten": "~4.4.0",
+				"markdownlint": "~0.18.0",
+				"markdownlint-rule-helpers": "~0.6.0",
+				"minimatch": "~3.0.4",
+				"rc": "~1.2.7"
+			}
+		},
+		"markdownlint-rule-helpers": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/markdownlint-rule-helpers/-/markdownlint-rule-helpers-0.6.0.tgz",
+			"integrity": "sha512-LiZVAbg9/cqkBHtLNNqHV3xuy4Y2L/KuGU6+ZXqCT9NnCdEkIoxeI5/96t+ExquBY0iHy2CVWxPH16nG1RKQVQ==",
+			"dev": true
+		},
+		"mdurl": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+			"integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
+			"dev": true
+		},
+		"minimatch": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
+			"requires": {
+				"brace-expansion": "^1.1.7"
+			}
+		},
+		"minimist": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+			"dev": true
+		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
+			"requires": {
+				"wrappy": "1"
+			}
+		},
+		"path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
+		},
+		"rc": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+			"dev": true,
+			"requires": {
+				"deep-extend": "^0.6.0",
+				"ini": "~1.3.0",
+				"minimist": "^1.2.0",
+				"strip-json-comments": "~2.0.1"
+			},
+			"dependencies": {
+				"deep-extend": {
+					"version": "0.6.0",
+					"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+					"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+					"dev": true
+				}
+			}
+		},
 		"semver": {
 			"version": "5.7.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
 			"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
 		},
+		"sprintf-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+			"dev": true
+		},
+		"strip-json-comments": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+			"dev": true
+		},
 		"typescript": {
 			"version": "3.5.2",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.2.tgz",
 			"integrity": "sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==",
+			"dev": true
+		},
+		"uc.micro": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+			"integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
 			"dev": true
 		},
 		"vscode-jsonrpc": {
@@ -53,6 +325,12 @@
 			"version": "3.14.0",
 			"resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.14.0.tgz",
 			"integrity": "sha512-lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A=="
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -144,11 +144,13 @@
 	"devDependencies": {
 		"@types/node": "^13.1.1",
 		"@types/vscode": "~1.20.0",
+		"markdownlint-cli": "0.20.0",
 		"typescript": "~3.5.2"
 	},
 	"scripts": {
 		"vscode:prepublish": "npm run compile",
 		"compile": "tsc -p ./",
+		"lint": "node_modules/.bin/markdownlint *.md",
 		"watch": "tsc -watch -p ./"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
 	"scripts": {
 		"vscode:prepublish": "npm run compile",
 		"compile": "tsc -p ./",
-		"lint": "node_modules/.bin/markdownlint *.md",
+		"lint": "npx markdownlint *.md",
 		"watch": "tsc -watch -p ./"
 	}
 }


### PR DESCRIPTION
Fixes the warnings that [markdownlint](https://github.com/DavidAnson/markdownlint) shows. Mostly whitespace issues, incorrect title levels in CHANGELOG.md and an issue with a raw link in README.md.

.markdownlint.json ignores line length and duplicate headers.