### PR TITLE
Inconsistent highlighting fixing and simplifying

### DIFF
--- a/syntaxes/v.tmLanguage.json
+++ b/syntaxes/v.tmLanguage.json
@@ -832,7 +832,7 @@
 			"patterns": [
 				{
 					"name": "meta.definition.interface.v",
-					"match": "(pub)?(interface)\\s+([0-9a-zA-Z_]*)",
+					"match": "\\s*(?:(pub)?\\s+)?(interface)\\s+([0-9a-zA-Z_]*)",
 					"captures": {
 						"1": {
 							"name": "keyword.pub.v"

--- a/syntaxes/v.tmLanguage.json
+++ b/syntaxes/v.tmLanguage.json
@@ -261,7 +261,7 @@
 						},
 						{
 							"name": "keyword.$1.v",
-							"match": "(fn|assert|sizeof)(?=\\s*\\()"
+							"match": "\\b(fn|assert|sizeof)\\b(?=\\s*\\()"
 						}
 					]
 				},
@@ -704,7 +704,7 @@
 							"include": "#struct-access-modifier"
 						},
 						{
-							"match": "\\b(\\w+)\\s+([\\w\\[\\].]+)(?:\\s*(=)\\s*((?:.(?=$|//|/\\*))*+))?",
+							"match": "\\b(\\w+)\\s+([\\w\\[\\]\\*&.]+)(?:\\s*(=)\\s*((?:.(?=$|//|/\\*))*+))?",
 							"captures": {
 								"1": {
 									"name": "variable.other.property.v"
@@ -777,24 +777,24 @@
 		"punctuation": {
 			"patterns": [
 				{
-					"match": "\\.",
-					"name": "punctuation.delimiter.period.dot.v"
+					"name": "punctuation.delimiter.period.dot.v",
+					"match": "\\."
 				},
 				{
-					"match": ",",
-					"name": "punctuation.delimiter.comma.v"
+					"name": "punctuation.delimiter.comma.v",
+					"match": ","
 				},
 				{
-					"match": ":",
-					"name": "punctuation.separator.key-value.colon.v"
+					"name": "punctuation.separator.key-value.colon.v",
+					"match": ":"
 				},
 				{
-					"match": ";",
-					"name": "punctuation.definition.other.semicolon.v"
+					"name": "punctuation.definition.other.semicolon.v",
+					"match": ";"
 				},
 				{
-					"match": "\\?",
-					"name": "punctuation.definition.other.questionmark.v"
+					"name": "punctuation.definition.other.questionmark.v",
+					"match": "\\?"
 				}
 			]
 		},

--- a/syntaxes/v.tmLanguage.json
+++ b/syntaxes/v.tmLanguage.json
@@ -1,11 +1,9 @@
 {
 	"name": "V",
-	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
-	"fileTypes": [".v", ".vh", ".vsh"],
 	"scopeName": "source.v",
 	"patterns": [
 		{
-			"name": "meta.definition.module.v",
+			"name": "meta.module.v",
 			"begin": "^\\s*(module)\\s+",
 			"beginCaptures": {
 				"1": {
@@ -20,7 +18,7 @@
 			}
 		},
 		{
-			"name": "meta.definition.import.v",
+			"name": "meta.import.v",
 			"begin": "^\\s*(import)\\s+",
 			"beginCaptures": {
 				"1": {
@@ -35,43 +33,22 @@
 			}
 		},
 		{
-			"name": "meta.definition.as.v",
-			"begin": "\\s+(as)\\s+",
-			"beginCaptures": {
-				"1": {
-					"name": "keyword.as.v"
-				}
-			},
-			"end": "([0-9a-zA-Z_.]*)",
-			"endCaptures": {
-				"1": {
-					"name": "entity.name.alias.v"
-				}
-			}
-		},
-		{
-			"name": "meta.definition.include.v",
+			"name": "meta.include.v",
 			"begin": "^\\s*(#include)",
 			"beginCaptures": {
 				"1": {
 					"name": "keyword.include.v"
 				}
 			},
-			"end": "\\s+([\\<\"])\\s*(.*)([\\>\"])",
+			"end": "\\s+(([\\<\"])\\s*(.*)([\\>\"]))",
 			"endCaptures": {
 				"1": {
-					"name": "string.quoted.double.v"
-				},
-				"2": {
-					"name": "string.quoted.double.v"
-				},
-				"3": {
 					"name": "string.quoted.double.v"
 				}
 			}
 		},
 		{
-			"name": "meta.definition.flag.v",
+			"name": "meta.flag.v",
 			"begin": "^\\s*(#flag)",
 			"beginCaptures": {
 				"1": {
@@ -86,25 +63,16 @@
 			}
 		},
 		{
-			"name": "meta.definition.reference.v",
-			"match": "(&)\\s*(?=[0-9a-zA-Z_])",
-			"captures": {
-				"1": {
-					"name": "keyword.operator.address.v"
-				}
-			}
-		},
-		{
-			"name": "meta.definition.escaped.keyword.v",
-			"match": "((?:@)(?:mut|pub|fn|module|import|as|const|map|assert|sizeof|type|struct|interface|enum|in|or|match|if|else|for|go|goto|defer|return|i?(?:8|16|nt|64|128)|u?(?:16|32|64|128)|f?(?:32|64)|bool|byte|byteptr|charptr|voidptr|string|ustring|rune|none))",
-			"captures": {
-				"0": {
-					"name": "keyword.other.escaped.v"
-				}
-			}
-		},
-		{
 			"include": "#comments"
+		},
+		{
+			"include": "#operators"
+		},
+		{
+			"include": "#as"
+		},
+		{
+			"include": "#assignment"
 		},
 		{
 			"include": "#attributes"
@@ -116,10 +84,10 @@
 			"include": "#builtin-fix"
 		},
 		{
-			"include": "#generics"
+			"include": "#escaped-fix"
 		},
 		{
-			"include": "#operators"
+			"include": "#constants"
 		},
 		{
 			"include": "#function-new-limited-overload"
@@ -134,6 +102,9 @@
 			"include": "#function-exist"
 		},
 		{
+			"include": "#generic"
+		},
+		{
 			"include": "#type"
 		},
 		{
@@ -146,63 +117,51 @@
 			"include": "#interface"
 		},
 		{
-			"include": "#constants"
-		},
-		{
-			"include": "#variable-assignment"
-		},
-		{
-			"include": "#variable-increment-decrement"
-		},
-		{
-			"include": "#goto"
-		},
-		{
 			"include": "#keywords"
-		},
-		{
-			"include": "#storage"
-		},
-		{
-			"include": "#std-types"
-		},
-		{
-			"include": "#std-cbased-types"
 		},
 		{
 			"include": "#numbers"
 		},
 		{
 			"include": "#strings"
+		},
+		{
+			"include": "#storage"
+		},
+		{
+			"include": "#std-types"
 		}
 	],
 	"repository": {
-		"flags": {
+		"as": {
+			"begin": "\\s+(as)\\s+",
+			"beginCaptures": {
+				"1": {
+					"name": "keyword.as.v"
+				}
+			},
+			"end": "([0-9a-zA-Z_.]*)",
+			"endCaptures": {
+				"1": {
+					"name": "entity.name.alias.v"
+				}
+			}
+		},
+		"assignment": {
 			"patterns": [
 				{
-					"name": "meta.flag.include.v",
-					"match": "(-L|I)\\s*(?=.+?)",
+					"name": "meta.definition.variable.v",
+					"match": "([0-9a-zA-Z_.]+)\\s*((?:\\:|\\+|\\-|\\*|\\/|\\%|\\&|\\||\\^)?=)\\s*(?=.+)",
 					"captures": {
 						"1": {
-							"name": "keyword.flag.include.v"
-						}
-					}
-				},
-				{
-					"name": "meta.flag.linking.v",
-					"match": "(-l[0-9a-zA-Z._\\-]+)",
-					"captures": {
-						"1": {
-							"name": "entity.name.library.v"
-						}
-					}
-				},
-				{
-					"name": "meta.flag.os-specific.linking.v",
-					"match": "(windows|darwin|linux|bsd)\\s+(?=-(?=l|L))",
-					"captures": {
-						"1": {
-							"name": "keyword.flag.os.v"
+							"name": "variable.assignment.other.v"
+						},
+						"2": {
+							"patterns":[
+								{
+									"include": "#operators"
+								}
+							]
 						}
 					}
 				}
@@ -211,7 +170,7 @@
 		"attributes": {
 			"patterns": [
 				{
-					"comment": "Before function definition",
+					"name": "meta.definition.attribute.v",
 					"match": "^\\s*((\\[)(unsafe_fn|deprecated|live|inline)(\\]))",
 					"captures": {
 						"1": {
@@ -229,22 +188,65 @@
 					}
 				},
 				{
-					"comment": "After struct literals",
-					"match": "(?<=[0-9a-zA-Z_\\s])((\\[)(skip)(\\]))",
+					"name": "meta.definition.support.attribute.v",
+					"match": "(?<=[0-9a-zA-Z_\\s])(?:(\\[)(skip)(\\]))",
 					"captures": {
-						"0": {
-							"name": "meta.struct.attribute.v"
-						},
-						"1": {
+						"1": { 
 							"name": "punctuation.definition.begin.bracket.square.v"
 						},
 						"2": {
-							"name": "entity.struct.attribute.v"
+							"name": "storage.modifier.support.attribute.v"
 						},
 						"3": {
 							"name": "punctuation.definition.end.bracket.square.v"
 						}
 					}
+				}
+			]
+		},
+		"brackets": {
+			"patterns": [
+				{
+					"begin": "\\{",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.bracket.curly.begin.v"
+						}
+					},
+					"end": "\\}",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.bracket.curly.end.v"
+						}
+					},
+					"patterns": [
+						{
+							"include": "$self"
+						}
+					]
+				},
+				{
+					"begin": "\\(",
+					"beginCaptures": {
+						"0": {
+							"name": "punctuation.definition.bracket.round.begin.v"
+						}
+					},
+					"end": "\\)",
+					"endCaptures": {
+						"0": {
+							"name": "punctuation.definition.bracket.round.end.v"
+						}
+					},
+					"patterns": [
+						{
+							"include": "$self"
+						}
+					]
+				},
+				{
+					"match": "\\[|\\]",
+					"name": "punctuation.definition.bracket.square.v"
 				}
 			]
 		},
@@ -261,6 +263,14 @@
 							}
 						},
 						{
+							"match": "(fn)(?=\\s*\\()",
+							"captures": {
+								"1": {
+									"name": "keyword.fn.v"
+								}
+							}	
+						},
+						{
 							"match": "(assert)(?=\\s*\\()",
 							"captures": {
 								"1": {
@@ -273,18 +283,6 @@
 							"captures": {
 								"1": {
 									"name": "keyword.sizeof.v"
-								}
-							}
-						}
-					]
-				},
-				{
-					"patterns": [
-						{
-							"match": "(in|or|match|if|else|for|go|goto|defer|return)(?=\\s*\\()",
-							"captures": {
-								"1": {
-									"name": "keyword.control.v"
 								}
 							}
 						}
@@ -377,55 +375,23 @@
 				}
 			]
 		},
-		"brackets": {
+		"escaped-fix": {
 			"patterns": [
 				{
-					"begin": "{",
-					"beginCaptures": {
+					"name": "meta.escaped.keyword.v",
+					"match": "((?:@)(?:mut|pub|fn|module|import|as|const|map|assert|sizeof|type|struct|interface|enum|in|or|match|if|else|for|go|goto|defer|return|i?(?:8|16|nt|64|128)|u?(?:16|32|64|128)|f?(?:32|64)|bool|byte|byteptr|charptr|voidptr|string|ustring|rune|none))",
+					"captures": {
 						"0": {
-							"name": "punctuation.definition.bracket.curly.begin.v"
+							"name": "keyword.other.escaped.v"
 						}
-					},
-					"end": "}",
-					"endCaptures": {
-						"0": {
-							"name": "punctuation.definition.bracket.curly.end.v"
-						}
-					},
-					"patterns": [
-						{
-							"include": "$self"
-						}
-					]
-				},
-				{
-					"begin": "\\(",
-					"beginCaptures": {
-						"0": {
-							"name": "punctuation.definition.bracket.round.begin.v"
-						}
-					},
-					"end": "\\)",
-					"endCaptures": {
-						"0": {
-							"name": "punctuation.definition.bracket.round.end.v"
-						}
-					},
-					"patterns": [
-						{
-							"include": "$self"
-						}
-					]
-				},
-				{
-					"match": "\\[|\\]",
-					"name": "punctuation.definition.bracket.square.v"
+					}
 				}
 			]
 		},
 		"comments": {
 			"patterns": [
 				{
+					"name": "comment.block.documentation.v",
 					"begin": "/\\*",
 					"beginCaptures": {
 						"0": {
@@ -442,18 +408,17 @@
 						{
 							"include": "#comments"
 						}
-					],
-					"name": "comment.block.documentation.v"
+					]
 				},
 				{
+					"name": "comment.line.double-slash.v",
 					"begin": "//",
 					"beginCaptures": {
 						"0": {
 							"name": "punctuation.definition.comment.begin.v"
 						}
 					},
-					"end": "$",
-					"name": "comment.line.double-slash.v"
+					"end": "$"
 				}
 			]
 		},
@@ -461,67 +426,11 @@
 			"patterns": [
 				{
 					"name": "constant.language.v",
-					"match": "\\b(true|false)\\b"
-				},
-				{
-					"name": "constant.other.v",
-					"match": "([0-9A-Z]+)(?=\\s*\\=)"
+					"match": "(true|false)"
 				}
 			]
 		},
-		"punctuation": {
-			"patterns": [
-				{
-					"match": "\\.",
-					"name": "punctuation.other.dot.v"
-				},
-				{
-					"match": "\\,",
-					"name": "punctuation.other.comma.v"
-				},
-				{
-					"match": "\\:",
-					"name": "punctuation.other.colon.v"
-				},
-				{
-					"match": "\\;",
-					"name": "punctuation.other.semicolon.v"
-				},
-				{
-					"match": "\\?",
-					"name": "punctuation.other.questionmark.v"
-				}
-			]
-		},
-		"generics": {
-			"patterns": [
-				{
-					"name": "meta.definition.generic.v",
-					"match": "(?<=[\\w\\s])(\\<)([0-9a-zA-Z_]+)(\\>)",
-					"captures": {
-						"1": {
-							"name": "punctuation.definition.bracket.angle.begin.v"
-						},
-						"2": {
-							"patterns": [
-								{
-									"match": "\\d\\w+",
-									"name": "invalid.illegal.v"
-								},
-								{
-									"match": "\\w+",
-									"name": "entity.name.generic.v"
-								}
-							]
-						},
-						"3": {
-							"name": "punctuation.definition.bracket.angle.end.v"
-						}
-					}
-				}
-			]
-		},
-		"function-generic": {
+		"generic": {
 			"patterns": [
 				{
 					"name": "meta.definition.generic.v",
@@ -549,62 +458,10 @@
 				}
 			]
 		},
-		"variable-assignment": {
-			"patterns": [
-				{
-					"match": "(match|if|else)(?=\\s*\\=\\>)",
-					"captures": {
-						"1": {
-							"name": "keyword.control.v"
-						}
-					}
-				},
-				{
-					"name": "meta.definition.var.v",
-					"match": "([0-9a-zA-Z_.]+)\\s*((?:\\:|\\+|\\-|\\*|\\/|\\%|\\&|\\||\\^)?=)\\s*(?=.+)",
-					"captures": {
-						"1": {
-							"name": "variable.other.v"
-						},
-						"2": {
-							"name": "keyword.operator.assignment.v"
-						}
-					}
-				}
-			]
-		},
-		"variable-increment-decrement": {
-			"patterns": [
-				{
-					"name": "meta.var.increment.expr.v",
-					"match": "([0-9a-zA-Z_.]+)(\\+\\+)",
-					"captures": {
-						"1": {
-							"name": "variable.other.increment.v"
-						},
-						"2": {
-							"name": "keyword.operator.increment.v"
-						}
-					}
-				},
-				{
-					"name": "meta.var.decrement.expr.v",
-					"match": "([0-9a-zA-Z_.]+)(\\-\\-)",
-					"captures": {
-						"1": {
-							"name": "variable.other.decrement.v"
-						},
-						"2": {
-							"name": "keyword.operator.decrement.v"
-						}
-					}
-				}
-			]
-		},
 		"function-new": {
 			"patterns": [
 				{
-					"name": "meta.function.v",
+					"name": "meta.definition.function.v",
 					"begin": "^\\s*(pub)?\\s*(fn)\\s+",
 					"beginCaptures": {
 						"1": {
@@ -616,9 +473,6 @@
 					},
 					"end": "(?:(?:C\\.)?)([0-9a-zA-Z_]+)(\\<[0-9a-zA-Z_]*\\>)?",
 					"endCaptures": {
-						"0": {
-							"name": "meta.definition.function.v"
-						},
 						"1": {
 							"patterns": [
 								{
@@ -634,7 +488,7 @@
 						"2": {
 							"patterns": [
 								{
-									"include": "#function-generic"
+									"include": "#generic"
 								}
 							]
 						}
@@ -645,12 +499,9 @@
 		"function-new-extend": {
 			"patterns": [
 				{
-					"name": "meta.function.v",
-					"match": "^\\s*(pub)?\\s*(fn)\\s+(\\()([^\\)]*)(\\))\\s*(?:(?:C\\.)?)([0-9a-zA-Z_]+)(\\<[0-9a-zA-Z_]*\\>)?",
+					"name": "meta.definition.function.v",
+					"match": "^\\s*(pub)?\\s*(fn)\\s*(\\()([^\\)]*)(\\))\\s*(?:(?:C\\.)?)([0-9a-zA-Z_]+)(\\<[0-9a-zA-Z_]*\\>)?",
 					"captures": {
-						"0": {
-							"name": "meta.definition.function.v"
-						},
 						"1": {
 							"name": "storage.modifier.v"
 						},
@@ -673,9 +524,6 @@
 								},
 								{
 									"include": "#std-types"
-								},
-								{
-									"include": "#std-cbased-types"
 								},
 								{
 									"include": "#punctuation"
@@ -700,7 +548,7 @@
 						"7": {
 							"patterns": [
 								{
-									"include": "#function-generic"
+									"include": "#generic"
 								}
 							]
 						}
@@ -711,12 +559,9 @@
 		"function-new-limited-overload": {
 			"patterns": [
 				{
-					"name": "meta.function.v",
-					"match": "^\\s*(pub)?\\s*(fn)\\s+(\\()([^\\)]*)(\\))\\s*([\\+\\-\\*\\/])?\\s*(\\()([^\\)]*)(\\))\\s*(?:(?:C\\.)?)([0-9a-zA-Z_]+)",
+					"name": "meta.definition.function.v",
+					"match": "^\\s*(pub)?\\s*(fn)\\s*(\\()([^\\)]*)(\\))\\s*([\\+\\-\\*\\/])?\\s*(\\()([^\\)]*)(\\))\\s*(?:(?:C\\.)?)([0-9a-zA-Z_]+)",
 					"captures": {
-						"0": {
-							"name": "meta.definition.function.v"
-						},
 						"1": {
 							"name": "storage.modifier.v"
 						},
@@ -739,9 +584,6 @@
 								},
 								{
 									"include": "#std-types"
-								},
-								{
-									"include": "#std-cbased-types"
 								},
 								{
 									"include": "#punctuation"
@@ -776,9 +618,6 @@
 									"include": "#std-types"
 								},
 								{
-									"include": "#std-cbased-types"
-								},
-								{
 									"include": "#punctuation"
 								}
 							]
@@ -805,7 +644,7 @@
 		"function-exist": {
 			"patterns": [
 				{
-					"name": "meta.function.v",
+					"name": "meta.support.function.v",
 					"match": "([0-9a-zA-Z_]+)(\\<[0-9a-zA-Z_]*\\>)?(?=\\s*\\()",
 					"captures": {
 						"0": {
@@ -826,7 +665,7 @@
 						"2": {
 							"patterns": [
 								{
-									"include": "#function-generic"
+									"include": "#generic"
 								}
 							]
 						}
@@ -837,14 +676,16 @@
 		"type": {
 			"patterns": [
 				{
-					"comment": "Type definition",
 					"name": "meta.definition.type.v",
-					"match": "^\\s*(\\btype\\b)\\s+([0-9a-zA-Z_]*)\\s+(?:[0-9a-zA-Z]+\\.+)?([0-9a-zA-Z_]*)",
+					"match": "\\s*(?:(pub)?\\s+)?(type)\\s+([0-9a-zA-Z_]*)\\s+(?:[0-9a-zA-Z]+\\.+)?([0-9a-zA-Z_]*)",
 					"captures": {
 						"1": {
-							"name": "keyword.type.v"
+							"name": "storage.modifier.$1.v"
 						},
 						"2": {
+							"name": "storage.type.type.v"
+						},
+						"3": {
 							"patterns": [
 								{
 									"name": "invalid.illegal.v",
@@ -856,7 +697,7 @@
 								}
 							]
 						},
-						"3": {
+						"4": {
 							"patterns": [
 								{
 									"name": "invalid.illegal.v",
@@ -875,24 +716,17 @@
 		"enum": {
 			"patterns": [
 				{
-					"comment": "Enumeration",
 					"name": "meta.definition.enum.v",
-					"match": "^\\s*(\\benum\\b)\\s+(?:[0-9a-zA-Z_]+\\.)?([0-9a-zA-Z_]*)",
+					"match": "\\s*(?:(pub)?\\s+)?(enum)\\s+(?:[0-9a-zA-Z_]+\\.)?([0-9a-zA-Z_]*)",
 					"captures": {
 						"1": {
-							"name": "keyword.enum.v"
+							"name": "storage.modifier.$1.v"
 						},
 						"2": {
-							"patterns": [
-								{
-									"name": "invalid.illegal.v",
-									"match": "\\d\\w+"
-								},
-								{
-									"name": "entity.name.enum.v",
-									"match": "\\w+"
-								}
-							]
+							"name": "storage.type.enum.v"
+						},
+						"3": {
+							"name": "entity.name.enum.v"
 						}
 					}
 				}
@@ -921,14 +755,14 @@
 					"endCaptures": {
 						"1": {
 							"name": "punctuation.definition.bracket.curly.end.v"
-						}
-					},
+						} 
+					}, 
 					"patterns": [
 						{
 							"include": "#struct-access-modifier"
 						},
 						{
-							"match": "\\b(\\w+)\\s+(\\w+)(?:\\s*(=)\\s*((?:.(?=$|//|/\\*))*+))?",
+							"match": "\\b(\\w+)\\s+([\\w\\[\\].]+)(?:\\s*(=)\\s*((?:.(?=$|//|/\\*))*+))?",
 							"captures": {
 								"1": {
 									"name": "variable.other.property.v"
@@ -936,14 +770,13 @@
 								"2": {
 									"patterns": [
 										{
+											"include": "#numbers"
+										},
+										{
+											"include": "#brackets"
+										},
+										{
 											"include": "#std-types"
-										},
-										{
-											"include": "#std-cbased-types"
-										},
-										{
-											"match": "\\w+",
-											"name": "storage.type.other.v"
 										}
 									]
 								},
@@ -961,9 +794,6 @@
 						},
 						{
 							"include": "#std-types"
-						},
-						{
-							"include": "#std-cbased-types"
 						},
 						{
 							"include": "$self"
@@ -1001,14 +831,16 @@
 		"interface": {
 			"patterns": [
 				{
-					"comment": "Interface",
 					"name": "meta.definition.interface.v",
-					"match": "^\\s*(\\binterface\\b)\\s+([0-9a-zA-Z_]*)",
+					"match": "(pub)?(interface)\\s+([0-9a-zA-Z_]*)",
 					"captures": {
 						"1": {
-							"name": "keyword.interface.v"
+							"name": "keyword.pub.v"
 						},
 						"2": {
+							"name": "keyword.interface.v"
+						},
+						"3": {
 							"patterns": [
 								{
 									"name": "invalid.illegal.v",
@@ -1021,6 +853,122 @@
 							]
 						}
 					}
+				}
+			]
+		},
+		"punctuation": {
+			"patterns": [
+				{
+					"match": "\\.",
+					"name": "punctuation.definition.other.dot.v"
+				},
+				{
+					"match": "\\,",
+					"name": "punctuation.definition.other.comma.v"
+				},
+				{
+					"match": "\\:",
+					"name": "punctuation.definition.other.colon.v"
+				},
+				{
+					"match": "\\;",
+					"name": "punctuation.definition.other.semicolon.v"
+				},
+				{
+					"match": "\\?",
+					"name": "punctuation.definition.other.questionmark.v"
+				}
+			]
+		},
+		"keywords": {
+			"patterns": [
+				{
+					"name": "keyword.control.v",
+					"match": "\\b(in|or|break|continue|default|match|if|else|for|go|goto|defer|return)\\b"
+				},
+				{
+					"name": "keyword.control.v",
+					"match": "(\\$if)"
+				},
+				{
+					"name": "keyword.control.v",
+					"match": "(\\$else)"
+				},
+				{
+					"name": "keyword.type.v",
+					"match": "\\btype\\b"
+				},
+				{
+					"name": "keyword.enum.v",
+					"match": "\\benum\\b"
+				},
+				{
+					"name": "keyword.struct.v",
+					"match": "\\bstruct\\b"
+				},
+				{
+					"name": "keyword.interface.v",
+					"match": "\\binterface\\b"
+				},
+				{
+					"name": "keyword.map.v",
+					"match": "\\bmap\\b"
+				},
+				{
+					"name": "keyword.assert.v",
+					"match": "\\bassert\\b"
+				},
+				{
+					"name": "keyword.sizeof.v",
+					"match": "\\bsizeof\\b"
+				}
+			]
+		},
+		"operators": {
+			"patterns": [
+				{
+					"name": "keyword.operator.arithmethic.v",
+					"match": "(\\+|\\-|\\*|\\/|\\%|\\+\\+|\\-\\-)"
+				},
+				{
+					"name": "keyword.operator.relation.v",
+					"match": "(\\=\\=|\\!\\=|\\>|\\<|\\>\\=|\\<\\=)"
+				},
+				{
+					"name": "keyword.operator.logical.v",
+					"match": "(\\&\\&|\\|\\||\\!)"
+				},
+				{
+					"name": "keyword.operator.bitwise.v",
+					"match": "(\\&|\\||\\^|<(?!<)|>(?!>))"
+				},
+				{
+					"name": "keyword.operator.assignment.v",
+					"match": "(\\:\\=|\\=|\\+\\=|\\-\\=|\\*\\=|\\/\\=|\\%\\=|\\&\\=|\\|\\=|\\^\\=|\\&\\&\\=|\\|\\|\\=|\\>\\>\\=|\\<\\<\\=)"
+				}
+			]
+		},
+		"numbers": {
+			"patterns": [
+				{
+					"name": "constant.numeric.float.v",
+					"match": "(?:(?:[-]?)(?:[0-9e]*)(?:[.]){1}(?:[0-9]+))"
+				},
+				{
+					"name": "constant.numeric.hex.v",
+					"match": "(?:0[xX])(?:[0-9a-fA-F]+)"
+				},
+				{
+					"name": "constant.numeric.integer.v",
+					"match": "\\b(?:[-]?)(?:[0-9]+)"
+				}
+			]
+		},
+		"storage": {
+			"patterns": [
+				{
+					"name": "storage.modifier.v",
+					"match": "\\b(const|mut|pub)\\b"
 				}
 			]
 		},
@@ -1072,141 +1020,6 @@
 				}
 			]
 		},
-		"std-cbased-types": {
-			"patterns": [
-				{
-					"name": "storage.type.numeric.cbased.v",
-					"match": "\\b(size_t|ptrdiff_t)\\b"
-				}
-			]
-		},
-		"operators": {
-			"patterns": [
-				{
-					"comment": "Arithmethic operators",
-					"name": "keyword.operator.arithmethic.v",
-					"match": "(\\+|\\-|\\*|\\/|\\%|\\+\\+|\\-\\-)"
-				},
-				{
-					"comment": "Relation operators",
-					"name": "keyword.operator.relation.v",
-					"match": "(\\=\\=|\\!\\=|\\>|\\<|\\>\\=|\\<\\=)"
-				},
-				{
-					"comment": "Logical operators",
-					"name": "keyword.operator.logical.v",
-					"match": "(\\&\\&|\\|\\||\\!)"
-				},
-				{
-					"comment": "Bitwise operators",
-					"name": "keyword.operator.bitwise.v",
-					"match": "(\\&|\\||\\^|<(?!<)|>(?!>))"
-				},
-				{
-					"comment": "Assignment  operators",
-					"name": "keyword.operator.assignment.v",
-					"match": "(\\:\\=|\\=|\\+\\=|\\-\\=|\\*\\=|\\/\\=|\\%\\=|\\&\\=|\\|\\=|\\^\\=|\\&\\&\\=|\\|\\|\\=|\\>\\>\\=|\\<\\<\\=)"
-				}
-			]
-		},
-		"keywords": {
-			"patterns": [
-				{
-					"comment": "Keyword Control",
-					"name": "keyword.control.v",
-					"match": "\\b(in|or|break|continue|default|match|if|else|for|go|goto|defer|return)\\b"
-				},
-				{
-					"name": "keyword.control.v",
-					"match": "(\\$if)"
-				},
-				{
-					"name": "keyword.control.v",
-					"match": "(\\$else)"
-				},
-				{
-					"comment": "Keyword Type",
-					"name": "keyword.type.v",
-					"match": "\\btype\\b"
-				},
-				{
-					"comment": "Keyword Based Enumeration",
-					"name": "keyword.enum.v",
-					"match": "\\benum\\b"
-				},
-				{
-					"comment": "Keyword Based Interface",
-					"name": "keyword.interface.v",
-					"match": "\\binterface\\b"
-				},
-				{
-					"comment": "Keyword Extended Map",
-					"name": "keyword.map.v",
-					"match": "\\bmap\\b"
-				},
-				{
-					"comment": "Keyword Extended Assert",
-					"name": "keyword.assert.v",
-					"match": "\\bassert\\b"
-				},
-				{
-					"comment": "Keyword Extended Sizeof",
-					"name": "keyword.sizeof.v",
-					"match": "\\bsizeof\\b"
-				}
-			]
-		},
-		"storage": {
-			"patterns": [
-				{
-					"name": "storage.modifier.v",
-					"match": "\\b(const|mut|pub)\\b"
-				}
-			]
-		},
-		"numbers": {
-			"patterns": [
-				{
-					"match": "([-]?)([0-9e]*)([.]){1}([0-9]+)",
-					"captures": {
-						"1": {
-							"name": "constant.numeric.float.v"
-						},
-						"2": {
-							"name": "constant.numeric.float.v"
-						},
-						"3": {
-							"name": "constant.numeric.float.v"
-						},
-						"4": {
-							"name": "constant.numeric.float.v"
-						}
-					}
-				},
-				{
-					"match": "(0[xX])([0-9a-fA-F]+)",
-					"captures": {
-						"1": {
-							"name": "constant.numeric.hex.v"
-						},
-						"2": {
-							"name": "constant.numeric.hex.v"
-						}
-					}
-				},
-				{
-					"match": "\\b([-]?)([0-9]+)",
-					"captures": {
-						"1": {
-							"name": "constant.numeric.integer.v"
-						},
-						"2": {
-							"name": "constant.numeric.integer.v"
-						}
-					}
-				}
-			]
-		},
 		"strings": {
 			"patterns": [
 				{
@@ -1225,10 +1038,10 @@
 					"name": "string.quoted.raw.v",
 					"patterns": [
 						{
-							"include": "#string-interpolation"
+							"include": "#string-escaped-char"
 						},
 						{
-							"include": "#string-escaped-char"
+							"include": "#string-interpolation"
 						},
 						{
 							"include": "#string-placeholder"
@@ -1251,10 +1064,10 @@
 					"name": "string.quoted.single.v",
 					"patterns": [
 						{
-							"include": "#string-interpolation"
+							"include": "#string-escaped-char"
 						},
 						{
-							"include": "#string-escaped-char"
+							"include": "#string-interpolation"
 						},
 						{
 							"include": "#string-placeholder"
@@ -1277,10 +1090,10 @@
 					"name": "string.quoted.double.v",
 					"patterns": [
 						{
-							"include": "#string-interpolation"
+							"include": "#string-escaped-char"
 						},
 						{
-							"include": "#string-escaped-char"
+							"include": "#string-interpolation"
 						},
 						{
 							"include": "#string-placeholder"

--- a/syntaxes/v.tmLanguage.json
+++ b/syntaxes/v.tmLanguage.json
@@ -777,6 +777,10 @@
 										},
 										{
 											"include": "#std-types"
+										},
+										{
+											"match": "\\w+",
+											"name": "storage.type.other.v"
 										}
 									]
 								},

--- a/syntaxes/v.tmLanguage.json
+++ b/syntaxes/v.tmLanguage.json
@@ -172,7 +172,7 @@
 			"patterns": [
 				{
 					"name": "meta.definition.attribute.v",
-					"match": "^\\s*((\\[)(unsafe_fn|deprecated|live|inline)(\\]))",
+					"match": "^\\s*((\\[)(deprecated|unsafe_fn|typedef|live|inline)(\\]))",
 					"captures": {
 						"1": {
 							"name": "meta.function.attribute.v"
@@ -293,7 +293,7 @@
 			"patterns": [
 				{
 					"name": "meta.escaped.keyword.v",
-					"match": "((?:@)(?:mut|pub|fn|module|import|as|const|map|assert|sizeof|type|struct|interface|enum|in|or|match|if|else|for|go|goto|defer|return|i?(?:8|16|nt|64|128)|u?(?:16|32|64|128)|f?(?:32|64)|bool|byte|byteptr|charptr|voidptr|string|ustring|rune|none))",
+					"match": "((?:@)(?:mut|pub|fn|unsafe|module|import|as|const|map|assert|sizeof|type|struct|interface|enum|in|or|match|if|else|for|go|goto|defer|return|i?(?:8|16|nt|64|128)|u?(?:16|32|64|128)|f?(?:32|64)|bool|byte|byteptr|charptr|voidptr|string|ustring|rune|none))",
 					"captures": {
 						"0": {
 							"name": "keyword.other.escaped.v"
@@ -572,7 +572,7 @@
 								},
 								{
 									"match": "\\w+",
-									"name": "support.function.v"
+									"name": "entity.name.function.v"
 								}
 							]
 						},
@@ -806,11 +806,11 @@
 				},
 				{
 					"name": "keyword.control.v",
-					"match": "\\b(in|or|break|continue|default|match|if|else|for|go|goto|defer|return)\\b"
+					"match": "\\b(in|or|break|continue|default|unsafe|match|if|else|for|go|goto|defer|return)\\b"
 				},
 				{
 					"name": "keyword.$1.v",
-					"match": "\\b(fn|type|enum|struct|interface|map|assert|sizeof)\\b"
+					"match": "\\b(fn|type|enum|unsafe|struct|interface|map|assert|sizeof)\\b"
 				}
 			]
 		},

--- a/syntaxes/v.tmLanguage.json
+++ b/syntaxes/v.tmLanguage.json
@@ -1,6 +1,7 @@
 {
 	"name": "V",
 	"scopeName": "source.v",
+	"fileTypes": [".v", ".vh", ".vsh"],
 	"patterns": [
 		{
 			"name": "meta.module.v",
@@ -10,7 +11,7 @@
 					"name": "keyword.module.v"
 				}
 			},
-			"end": "([0-9a-zA-Z_]*)",
+			"end": "([\\w.]+)",
 			"endCaptures": {
 				"1": {
 					"name": "entity.name.module.v"
@@ -25,7 +26,7 @@
 					"name": "keyword.import.v"
 				}
 			},
-			"end": "([0-9a-zA-Z_.]*)",
+			"end": "([\\w.]+)",
 			"endCaptures": {
 				"1": {
 					"name": "entity.name.import.v"
@@ -90,13 +91,13 @@
 			"include": "#constants"
 		},
 		{
-			"include": "#function-new-limited-overload"
+			"include": "#function-limited-overload-declaration"
 		},
 		{
-			"include": "#function-new-extend"
+			"include": "#function-extend-declaration"
 		},
 		{
-			"include": "#function-new"
+			"include": "#function-declaration"
 		},
 		{
 			"include": "#function-exist"
@@ -111,10 +112,10 @@
 			"include": "#enum"
 		},
 		{
-			"include": "#struct"
+			"include": "#interface"
 		},
 		{
-			"include": "#interface"
+			"include": "#struct"
 		},
 		{
 			"include": "#keywords"
@@ -140,7 +141,7 @@
 					"name": "keyword.as.v"
 				}
 			},
-			"end": "([0-9a-zA-Z_.]*)",
+			"end": "([\\w.]*)",
 			"endCaptures": {
 				"1": {
 					"name": "entity.name.alias.v"
@@ -151,13 +152,13 @@
 			"patterns": [
 				{
 					"name": "meta.definition.variable.v",
-					"match": "([0-9a-zA-Z_.]+)\\s*((?:\\:|\\+|\\-|\\*|\\/|\\%|\\&|\\||\\^)?=)\\s*(?=.+)",
+					"match": "([\\w.]+)\\s*((?:\\:|\\+|\\-|\\*|\\/|\\%|\\&|\\||\\^)?=)\\s*(?=.+)",
 					"captures": {
 						"1": {
 							"name": "variable.assignment.other.v"
 						},
 						"2": {
-							"patterns":[
+							"patterns": [
 								{
 									"include": "#operators"
 								}
@@ -189,9 +190,9 @@
 				},
 				{
 					"name": "meta.definition.support.attribute.v",
-					"match": "(?<=[0-9a-zA-Z_\\s])(?:(\\[)(skip)(\\]))",
+					"match": "(?<=[\\w\\s])(?:(\\[)(skip)(\\]))",
 					"captures": {
-						"1": { 
+						"1": {
 							"name": "punctuation.definition.begin.bracket.square.v"
 						},
 						"2": {
@@ -207,13 +208,13 @@
 		"brackets": {
 			"patterns": [
 				{
-					"begin": "\\{",
+					"begin": "{",
 					"beginCaptures": {
 						"0": {
 							"name": "punctuation.definition.bracket.curly.begin.v"
 						}
 					},
-					"end": "\\}",
+					"end": "}",
 					"endCaptures": {
 						"0": {
 							"name": "punctuation.definition.bracket.curly.end.v"
@@ -255,36 +256,12 @@
 				{
 					"patterns": [
 						{
-							"match": "^\\s*(const)(?=\\s*\\()",
-							"captures": {
-								"1": {
-									"name": "storage.modifier.v"
-								}
-							}
+							"name": "storage.modifier.v",
+							"match": "^\\s*(const)(?=\\s*\\()"
 						},
 						{
-							"match": "(fn)(?=\\s*\\()",
-							"captures": {
-								"1": {
-									"name": "keyword.fn.v"
-								}
-							}	
-						},
-						{
-							"match": "(assert)(?=\\s*\\()",
-							"captures": {
-								"1": {
-									"name": "keyword.assert.v"
-								}
-							}
-						},
-						{
-							"match": "(sizeof)(?=\\s*\\()",
-							"captures": {
-								"1": {
-									"name": "keyword.sizeof.v"
-								}
-							}
+							"name": "keyword.$1.v",
+							"match": "(fn|assert|sizeof)(?=\\s*\\()"
 						}
 					]
 				},
@@ -300,76 +277,13 @@
 							"name": "meta.expr.numeric.cast.v"
 						},
 						{
-							"match": "(bool)(?=\\s*\\()",
+							"match": "(bool|byte|byteptr|charptr|voidptr|string|ustring|rune|none)(?=\\s*\\()",
 							"captures": {
 								"1": {
-									"name": "storage.type.boolean.v"
+									"name": "storage.type.$1.v"
 								}
 							},
 							"name": "meta.expr.bool.cast.v"
-						},
-						{
-							"match": "(byte)(?=\\s*\\()",
-							"captures": {
-								"1": {
-									"name": "storage.type.byte.v"
-								}
-							},
-							"name": "meta.expr.byte.cast.v"
-						},
-						{
-							"match": "(byteptr)(?=\\s*\\()",
-							"captures": {
-								"1": {
-									"name": "storage.type.byteptr.v"
-								}
-							},
-							"name": "meta.expr.byteptr.cast.v"
-						},
-						{
-							"match": "(voidptr)(?=\\s*\\()",
-							"captures": {
-								"1": {
-									"name": "storage.type.voidptr.v"
-								}
-							},
-							"name": "meta.expr.voidptr.cast.v"
-						},
-						{
-							"match": "(string)(?=\\s*\\()",
-							"captures": {
-								"1": {
-									"name": "storage.type.string.v"
-								}
-							},
-							"name": "meta.expr.string.cast.v"
-						},
-						{
-							"match": "(ustring)(?=\\s*\\()",
-							"captures": {
-								"1": {
-									"name": "storage.type.ustring.v"
-								}
-							},
-							"name": "meta.expr.ustring.cast.v"
-						},
-						{
-							"match": "(rune)(?=\\s*\\()",
-							"captures": {
-								"1": {
-									"name": "storage.type.rune.v"
-								}
-							},
-							"name": "meta.expr.rune.cast.v"
-						},
-						{
-							"match": "(none)(?=\\s*\\()",
-							"captures": {
-								"1": {
-									"name": "storage.type.none.v"
-								}
-							},
-							"name": "meta.expr.none.cast.v"
 						}
 					]
 				}
@@ -426,7 +340,7 @@
 			"patterns": [
 				{
 					"name": "constant.language.v",
-					"match": "(true|false)"
+					"match": "\\b(true|false)\\b"
 				}
 			]
 		},
@@ -434,7 +348,7 @@
 			"patterns": [
 				{
 					"name": "meta.definition.generic.v",
-					"match": "(\\<)([0-9a-zA-Z_]+)(\\>)",
+					"match": "(\\<)([\\w]+)(\\>)",
 					"captures": {
 						"1": {
 							"name": "punctuation.definition.bracket.angle.begin.v"
@@ -458,7 +372,7 @@
 				}
 			]
 		},
-		"function-new": {
+		"function-declaration": {
 			"patterns": [
 				{
 					"name": "meta.definition.function.v",
@@ -471,7 +385,7 @@
 							"name": "keyword.function.v"
 						}
 					},
-					"end": "(?:(?:C\\.)?)([0-9a-zA-Z_]+)(\\<[0-9a-zA-Z_]*\\>)?",
+					"end": "(?:(?:C\\.)?)([\\w]+)(\\<[\\w]*\\>)?",
 					"endCaptures": {
 						"1": {
 							"patterns": [
@@ -496,11 +410,11 @@
 				}
 			]
 		},
-		"function-new-extend": {
+		"function-extend-declaration": {
 			"patterns": [
 				{
 					"name": "meta.definition.function.v",
-					"match": "^\\s*(pub)?\\s*(fn)\\s*(\\()([^\\)]*)(\\))\\s*(?:(?:C\\.)?)([0-9a-zA-Z_]+)(\\<[0-9a-zA-Z_]*\\>)?",
+					"match": "^\\s*(pub)?\\s*(fn)\\s*(\\()([^\\)]*)(\\))\\s*(?:(?:C\\.)?)([\\w]+)(\\<[\\w]*\\>)?",
 					"captures": {
 						"1": {
 							"name": "storage.modifier.v"
@@ -556,11 +470,11 @@
 				}
 			]
 		},
-		"function-new-limited-overload": {
+		"function-limited-overload-declaration": {
 			"patterns": [
 				{
 					"name": "meta.definition.function.v",
-					"match": "^\\s*(pub)?\\s*(fn)\\s*(\\()([^\\)]*)(\\))\\s*([\\+\\-\\*\\/])?\\s*(\\()([^\\)]*)(\\))\\s*(?:(?:C\\.)?)([0-9a-zA-Z_]+)",
+					"match": "^\\s*(pub)?\\s*(fn)\\s*(\\()([^\\)]*)(\\))\\s*([\\+\\-\\*\\/])?\\s*(\\()([^\\)]*)(\\))\\s*(?:(?:C\\.)?)([\\w]+)",
 					"captures": {
 						"1": {
 							"name": "storage.modifier.v"
@@ -645,7 +559,7 @@
 			"patterns": [
 				{
 					"name": "meta.support.function.v",
-					"match": "([0-9a-zA-Z_]+)(\\<[0-9a-zA-Z_]*\\>)?(?=\\s*\\()",
+					"match": "([\\w]+)(\\<[\\w]*\\>)?(?=\\s*\\()",
 					"captures": {
 						"0": {
 							"name": "meta.function.call.v"
@@ -677,7 +591,7 @@
 			"patterns": [
 				{
 					"name": "meta.definition.type.v",
-					"match": "\\s*(?:(pub)?\\s+)?(type)\\s+([0-9a-zA-Z_]*)\\s+(?:[0-9a-zA-Z]+\\.+)?([0-9a-zA-Z_]*)",
+					"match": "\\s*(?:(pub)?\\s+)?(type)\\s+([\\w]*)\\s+(?:[\\w]+\\.+)?([\\w]*)",
 					"captures": {
 						"1": {
 							"name": "storage.modifier.$1.v"
@@ -717,7 +631,7 @@
 			"patterns": [
 				{
 					"name": "meta.definition.enum.v",
-					"match": "\\s*(?:(pub)?\\s+)?(enum)\\s+(?:[0-9a-zA-Z_]+\\.)?([0-9a-zA-Z_]*)",
+					"match": "\\s*(?:(pub)?\\s+)?(enum)\\s+(?:[\\w]+\\.)?([\\w]*)",
 					"captures": {
 						"1": {
 							"name": "storage.modifier.$1.v"
@@ -732,11 +646,39 @@
 				}
 			]
 		},
+		"interface": {
+			"patterns": [
+				{
+					"name": "meta.definition.interface.v",
+					"match": "\\s*(?:(pub)?\\s+)?(interface)\\s+([\\w]*)",
+					"captures": {
+						"1": {
+							"name": "keyword.pub.v"
+						},
+						"2": {
+							"name": "keyword.interface.v"
+						},
+						"3": {
+							"patterns": [
+								{
+									"name": "invalid.illegal.v",
+									"match": "\\d\\w+"
+								},
+								{
+									"name": "entity.name.interface.v",
+									"match": "\\w+"
+								}
+							]
+						}
+					}
+				}
+			]
+		},
 		"struct": {
 			"patterns": [
 				{
 					"name": "meta.definition.struct.v",
-					"begin": "\\s*(?:(mut|pub(?:\\s+mut)?|__global)\\s+)?(struct)\\s+([0-9a-zA-Z_.]+)\\s*({)",
+					"begin": "\\s*(?:(mut|pub(?:\\s+mut)?|__global)\\s+)?(struct)\\s+([\\w.]+)\\s*({)",
 					"beginCaptures": {
 						"1": {
 							"name": "storage.modifier.$1.v"
@@ -755,8 +697,8 @@
 					"endCaptures": {
 						"1": {
 							"name": "punctuation.definition.bracket.curly.end.v"
-						} 
-					}, 
+						}
+					},
 					"patterns": [
 						{
 							"include": "#struct-access-modifier"
@@ -806,7 +748,7 @@
 				},
 				{
 					"name": "meta.definition.struct.v",
-					"match": "(?:(mut|pub(?:\\s+mut)?|__global)\\s+)?(struct)(?:\\s+([0-9a-zA-Z_.]+))?",
+					"match": "(?:(mut|pub(?:\\s+mut)?|__global)\\s+)?(struct)(?:\\s+([\\w.]+))?",
 					"captures": {
 						"1": {
 							"name": "storage.modifier.$1.v"
@@ -832,50 +774,22 @@
 				}
 			}
 		},
-		"interface": {
-			"patterns": [
-				{
-					"name": "meta.definition.interface.v",
-					"match": "\\s*(?:(pub)?\\s+)?(interface)\\s+([0-9a-zA-Z_]*)",
-					"captures": {
-						"1": {
-							"name": "keyword.pub.v"
-						},
-						"2": {
-							"name": "keyword.interface.v"
-						},
-						"3": {
-							"patterns": [
-								{
-									"name": "invalid.illegal.v",
-									"match": "\\d\\w+"
-								},
-								{
-									"name": "entity.name.interface.v",
-									"match": "\\w+"
-								}
-							]
-						}
-					}
-				}
-			]
-		},
 		"punctuation": {
 			"patterns": [
 				{
 					"match": "\\.",
-					"name": "punctuation.definition.other.dot.v"
+					"name": "punctuation.delimiter.period.dot.v"
 				},
 				{
-					"match": "\\,",
-					"name": "punctuation.definition.other.comma.v"
+					"match": ",",
+					"name": "punctuation.delimiter.comma.v"
 				},
 				{
-					"match": "\\:",
-					"name": "punctuation.definition.other.colon.v"
+					"match": ":",
+					"name": "punctuation.separator.key-value.colon.v"
 				},
 				{
-					"match": "\\;",
+					"match": ";",
 					"name": "punctuation.definition.other.semicolon.v"
 				},
 				{
@@ -888,43 +802,15 @@
 			"patterns": [
 				{
 					"name": "keyword.control.v",
+					"match": "(\\$if|\\$else)"
+				},
+				{
+					"name": "keyword.control.v",
 					"match": "\\b(in|or|break|continue|default|match|if|else|for|go|goto|defer|return)\\b"
 				},
 				{
-					"name": "keyword.control.v",
-					"match": "(\\$if)"
-				},
-				{
-					"name": "keyword.control.v",
-					"match": "(\\$else)"
-				},
-				{
-					"name": "keyword.type.v",
-					"match": "\\btype\\b"
-				},
-				{
-					"name": "keyword.enum.v",
-					"match": "\\benum\\b"
-				},
-				{
-					"name": "keyword.struct.v",
-					"match": "\\bstruct\\b"
-				},
-				{
-					"name": "keyword.interface.v",
-					"match": "\\binterface\\b"
-				},
-				{
-					"name": "keyword.map.v",
-					"match": "\\bmap\\b"
-				},
-				{
-					"name": "keyword.assert.v",
-					"match": "\\bassert\\b"
-				},
-				{
-					"name": "keyword.sizeof.v",
-					"match": "\\bsizeof\\b"
+					"name": "keyword.$1.v",
+					"match": "\\b(fn|type|enum|struct|interface|map|assert|sizeof)\\b"
 				}
 			]
 		},
@@ -935,20 +821,20 @@
 					"match": "(\\+|\\-|\\*|\\/|\\%|\\+\\+|\\-\\-)"
 				},
 				{
-					"name": "keyword.operator.relation.v",
-					"match": "(\\=\\=|\\!\\=|\\>|\\<|\\>\\=|\\<\\=)"
-				},
-				{
-					"name": "keyword.operator.logical.v",
-					"match": "(\\&\\&|\\|\\||\\!)"
+					"name": "keyword.operator.assignment.v",
+					"match": "(\\:\\=|\\=|\\+\\=|\\-\\=|\\*\\=|\\/\\=|\\%\\=|\\&\\=|\\|\\=|\\^\\=|\\&\\&\\=|\\|\\|\\=|\\>\\>\\=|\\<\\<\\=)"
 				},
 				{
 					"name": "keyword.operator.bitwise.v",
 					"match": "(\\&|\\||\\^|<(?!<)|>(?!>))"
 				},
 				{
-					"name": "keyword.operator.assignment.v",
-					"match": "(\\:\\=|\\=|\\+\\=|\\-\\=|\\*\\=|\\/\\=|\\%\\=|\\&\\=|\\|\\=|\\^\\=|\\&\\&\\=|\\|\\|\\=|\\>\\>\\=|\\<\\<\\=)"
+					"name": "keyword.operator.logical.v",
+					"match": "(\\&\\&|\\|\\||\\!)"
+				},
+				{
+					"name": "keyword.operator.relation.v",
+					"match": "(\\=\\=|\\!\\=|\\>|\\<|\\>\\=|\\<\\=)"
 				}
 			]
 		},
@@ -960,7 +846,7 @@
 				},
 				{
 					"name": "constant.numeric.hex.v",
-					"match": "(?:0[xX])(?:[0-9a-fA-F]+)"
+					"match": "\\b(?:0[xX])(?:[0-9a-fA-F]+)"
 				},
 				{
 					"name": "constant.numeric.integer.v",
@@ -979,61 +865,25 @@
 		"std-types": {
 			"patterns": [
 				{
-					"name": "storage.type.boolean.v",
-					"match": "\\bbool\\b"
-				},
-				{
-					"name": "storage.type.byte.v",
-					"match": "\\bbyte\\b"
-				},
-				{
-					"name": "storage.type.byteptr.v",
-					"match": "\\bbyteptr\\b"
-				},
-				{
-					"name": "storage.type.charptr.v",
-					"match": "\\bcharptr\\b"
-				},
-				{
-					"name": "storage.type.voidptr.v",
-					"match": "\\bvoidptr\\b"
-				},
-				{
-					"name": "storage.type.string.v",
-					"match": "\\bstring\\b"
-				},
-				{
-					"name": "storage.type.ustring.v",
-					"match": "\\bustring\\b"
-				},
-				{
-					"name": "storage.type.rune.v",
-					"match": "\\brune\\b"
-				},
-				{
-					"name": "storage.type.option.v",
-					"match": "\\boption\\b"
-				},
-				{
 					"name": "storage.type.numeric.v",
 					"match": "\\b(i(8|16|nt|64|128)|u(16|32|64|u128)|f(32|64))\\b"
 				},
 				{
-					"name": "storage.type.none.v",
-					"match": "\\bnone\\b"
+					"name": "storage.type.$1.v",
+					"match": "\\b(bool|byte|byteptr|charptr|voidptr|string|ustring|rune|none)\\b"
 				}
 			]
 		},
 		"strings": {
 			"patterns": [
 				{
-					"begin": "\\`",
+					"begin": "`",
 					"beginCaptures": {
 						"0": {
 							"name": "punctuation.definition.string.raw.begin.v"
 						}
 					},
-					"end": "\\`",
+					"end": "`",
 					"endCaptures": {
 						"0": {
 							"name": "punctuation.definition.string.raw.end.v"
@@ -1053,13 +903,13 @@
 					]
 				},
 				{
-					"begin": "\\'",
+					"begin": "'",
 					"beginCaptures": {
 						"0": {
 							"name": "punctuation.definition.string.single.begin.v"
 						}
 					},
-					"end": "\\'",
+					"end": "'",
 					"endCaptures": {
 						"0": {
 							"name": "punctuation.definition.string.single.end.v"
@@ -1109,12 +959,12 @@
 		"string-escaped-char": {
 			"patterns": [
 				{
-					"match": "\\\\([0-7]{3}|[\\$abfnrtv\\\\'\"]|x[0-9a-fA-F]{2}|u[0-9a-fA-F]{4}|U[0-9a-fA-F]{8})",
-					"name": "constant.character.escape.v"
+					"name": "constant.character.escape.v",
+					"match": "\\\\([0-7]{3}|[\\$abfnrtv\\\\'\"]|x[0-9a-fA-F]{2}|u[0-9a-fA-F]{4}|U[0-9a-fA-F]{8})"
 				},
 				{
-					"match": "\\\\[^0-7\\$xuUabfnrtv\\'\"]",
-					"name": "invalid.illegal.unknown-escape.v"
+					"name": "invalid.illegal.unknown-escape.v",
+					"match": "\\\\[^0-7\\$xuUabfnrtv\\'\"]"
 				}
 			]
 		},
@@ -1122,7 +972,7 @@
 			"patterns": [
 				{
 					"name": "meta.string.interpolation.v",
-					"match": "(\\$([0-9a-zA-Z_.]+|\\{.*?\\}))",
+					"match": "(\\$([\\w.]+|\\{.*?\\}))",
 					"captures": {
 						"1": {
 							"patterns": [
@@ -1138,7 +988,7 @@
 						}
 					}
 				}
-			] 
+			]
 		},
 		"string-placeholder": {
 			"patterns": [
@@ -1147,6 +997,6 @@
 					"name": "constant.other.placeholder.v"
 				}
 			]
-		} 
+		}
 	}
 }


### PR DESCRIPTION
* Deleted unused entries.
* Dropped `$schema` and `fileTypes`.
* Fixed inconsistent pattern for field attributes abstraction. 
* Fixed inconsistent highlighting for `fn`
* Fixed inconsistent highlighting for `struct`, `enum`, `type`, `interface`  https://github.com/0x9ef/vscode-vlang/issues/60.
* Simplified numbers pattern.
