### PR TITLE
Remove `v.format.enable` config and honor the builtin vscode format config

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,12 +61,6 @@
 		"configuration": {
 			"title": "V",
 			"properties": {
-				"v.format.enable": {
-					"scope": "resource",
-					"type": "boolean",
-					"default": false,
-					"description": "Enable/disable the V formatter (vfmt)"
-				},
 				"v.format.args": {
 					"scope": "resource",
 					"type": "string",

--- a/src/client/format.ts
+++ b/src/client/format.ts
@@ -31,18 +31,10 @@ function format(document: vscode.TextDocument): Promise<vscode.TextEdit[]> {
 }
 
 export function registerFormatter() {
-	const formatterEnabled = vscode.workspace.getConfiguration('v.format').get('enable');
-	if (!formatterEnabled) {
-		console.log('Formatter not enabled!');
-		return;
-	}
-
 	const provider: vscode.DocumentFormattingEditProvider = {
-		provideDocumentFormattingEdits(
-			document: vscode.TextDocument
-		): Thenable<vscode.TextEdit[]> {
+		provideDocumentFormattingEdits(document: vscode.TextDocument): Thenable<vscode.TextEdit[]> {
 			return document.save().then(() => format(document));
-		}
+		},
 	};
 	vscode.languages.registerDocumentFormattingEditProvider('v', provider);
 }


### PR DESCRIPTION
It's the new version of #57. Description here => https://github.com/0x9ef/vscode-vlang/pull/57#issuecomment-569980148