### PR TITLE
Fix changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Autoclosed multilines comments (block) [012e640](https://github.com/0x9ef/vscode-vlang/commit/012e640a84772162a7d822c3b87890c20244fa78)
 
-## [0.0.5] - 2019-06-05
+## [0.0.5] - 2019-06-30
 
 ### Added
 
@@ -124,8 +124,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Invalid pattern for variable assignment.
 - Invalid pattern for label (conflict with default keyword) __`default:`__
 
-### Changed
-
 - Included pattern for variable increment, decrement.
 
 ## [0.0.3] - 2019-06-16
@@ -140,10 +138,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Invalid pattern for float numeric.
 - Invalid pattern for new/exist function.
-
-### Changed
-
-### Removed
 
 ## [0.0.2] - 2019-06-12
 
@@ -163,8 +157,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Highligting for `module, import, struct, enum, interface` from `default` to `bold underline`.
 
-### Removed
-
 ## [0.0.1] - 2019-06-10
 
 ### Added
@@ -176,7 +168,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Images in `/images` folder.
 - Icon theme in `/theme/icon-theme.json`.
 - Icon for `.v` based files in `theme/images/v.svg`.
-
-### Changed
-
-### Removed


### PR DESCRIPTION
Remove empty sections to keep consistent style of changelog.
Fix release date of v0.0.5 (I used a date of 857b766ac2c9bab61c6562e24ba6f83e7c543709 commit).