### PR TITLE
Replace VSCode deprecated API with the new API

### DIFF
--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -13,12 +13,12 @@ export function activate(context: vscode.ExtensionContext) {
 	let help = vscode.commands.registerCommand('v.help', commands.help);
 	let ver = vscode.commands.registerCommand('v.ver', commands.ver);
 	let path = vscode.commands.registerCommand('v.path', commands.path);
-	let testFile = vscode.commands.registerCommand('v.test.file',commands.testFile);
-	let testPackage = vscode.commands.registerCommand('v.test.package',commands.testPackage);
-	let playground = vscode.commands.registerCommand('v.playground',commands.playground);
+	let testFile = vscode.commands.registerCommand('v.test.file', commands.testFile);
+	let testPackage = vscode.commands.registerCommand('v.test.package', commands.testPackage);
+	let playground = vscode.commands.registerCommand('v.playground', commands.playground);
 
 	registerFormatter();
-	attachOnCloseTerminalListener()
+	attachOnCloseTerminalListener();
 }
 
 /**

--- a/src/client/format.ts
+++ b/src/client/format.ts
@@ -25,7 +25,7 @@ function format(document: vscode.TextDocument): Promise<vscode.TextEdit[]> {
 		}
 
 		console.log(`Running ${cmd}...`);
-		childProcess.exec(cmd, { cwd: workspace.uri.path }, callback);
+		childProcess.exec(cmd, { cwd: workspace.uri.fsPath }, callback);
 	});
 }
 

--- a/src/client/format.ts
+++ b/src/client/format.ts
@@ -9,7 +9,7 @@ function format(document: vscode.TextDocument): Promise<vscode.TextEdit[]> {
 			vscode.workspace.getConfiguration('v.format').get('args') || '';
 		const cmd = `v fmt ${vfmtArgs} ${document.fileName}`;
 
-		// Create new `callback` function for 
+		// Create new `callback` function for
 		function callback(
 			error: childProcess.ExecException,
 			stdout: string,
@@ -24,9 +24,8 @@ function format(document: vscode.TextDocument): Promise<vscode.TextEdit[]> {
 			return resolve([vscode.TextEdit.replace(fullDocumentRange(document), stdout)]);
 		}
 
-		// TODO: vscode.workspace.rootPath is deprecated.
 		console.log(`Running ${cmd}...`);
-		childProcess.exec(cmd, { cwd: vscode.workspace.rootPath }, callback);
+		childProcess.exec(cmd, { cwd: vscode.workspace.workspaceFolders[0].name }, callback);
 	});
 }
 
@@ -34,7 +33,7 @@ export function registerFormatter() {
 	const provider: vscode.DocumentFormattingEditProvider = {
 		provideDocumentFormattingEdits(document: vscode.TextDocument): Thenable<vscode.TextEdit[]> {
 			return document.save().then(() => format(document));
-		},
+		}
 	};
 	vscode.languages.registerDocumentFormattingEditProvider('v', provider);
 }

--- a/src/client/format.ts
+++ b/src/client/format.ts
@@ -5,9 +5,9 @@ import { fullDocumentRange } from './utils';
 function format(document: vscode.TextDocument): Promise<vscode.TextEdit[]> {
 	return new Promise((resolve, reject) => {
 		// Create `vfmt` command with entered arguments.
-		const vfmtArgs: string =
-			vscode.workspace.getConfiguration('v.format').get('args') || '';
+		const vfmtArgs: string = vscode.workspace.getConfiguration('v.format').get('args') || '';
 		const cmd = `v fmt ${vfmtArgs} ${document.fileName}`;
+		const workspace = vscode.workspace.workspaceFolders[0]
 
 		// Create new `callback` function for
 		function callback(
@@ -25,7 +25,7 @@ function format(document: vscode.TextDocument): Promise<vscode.TextEdit[]> {
 		}
 
 		console.log(`Running ${cmd}...`);
-		childProcess.exec(cmd, { cwd: vscode.workspace.workspaceFolders[0].name }, callback);
+		childProcess.exec(cmd, { cwd: workspace.uri.path }, callback);
 	});
 }
 

--- a/src/client/format.ts
+++ b/src/client/format.ts
@@ -7,7 +7,7 @@ function format(document: vscode.TextDocument): Promise<vscode.TextEdit[]> {
 		// Create `vfmt` command with entered arguments.
 		const vfmtArgs: string = vscode.workspace.getConfiguration('v.format').get('args') || '';
 		const cmd = `v fmt ${vfmtArgs} ${document.fileName}`;
-		const workspace = vscode.workspace.workspaceFolders[0]
+		const workspace = vscode.workspace.workspaceFolders[0];
 
 		// Create new `callback` function for
 		function callback(

--- a/src/client/run.ts
+++ b/src/client/run.ts
@@ -5,15 +5,13 @@ let vRunTerm: vscode.Terminal = null;
 export function vrun() {
 	const cmd = 'v run ' + vscode.window.activeTextEditor.document.fileName;
 	vscode.window.activeTextEditor.document.save();
-	if (!vRunTerm) {
-		vRunTerm = vscode.window.createTerminal('V');
-	}
+	if (!vRunTerm) vRunTerm = vscode.window.createTerminal('V');
 	vRunTerm.show();
 	vRunTerm.sendText(cmd);
 }
 
 export function attachOnCloseTerminalListener() {
-	vscode.window.onDidCloseTerminal((term)=> {
+	vscode.window.onDidCloseTerminal(term => {
 		if (term.name == 'V') vRunTerm = null;
-	})
+	});
 }

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -2,10 +2,5 @@ import * as vscode from 'vscode';
 
 export function fullDocumentRange(document: vscode.TextDocument): vscode.Range {
 	const lastLineId = document.lineCount - 1;
-	return new vscode.Range(
-		0,
-		0,
-		lastLineId,
-		document.lineAt(lastLineId).text.length,
-	); 
+	return new vscode.Range(0, 0, lastLineId, document.lineAt(lastLineId).text.length);
 }


### PR DESCRIPTION
Replace VSCode deprecated API with the new API. As said in the [VSCode documentation](https://code.visualstudio.com/api/references/vscode-api#workspace) that `workspace.rootPath` has been deprecated. 
```
rootPath: string | undefined

The folder that is open in the editor. undefined when no folder has been opened.

deprecated - Use workspaceFolders instead.
```

Also... got this from `debug console`
```log
[Deprecation Warning] 'workspace.rootPath' is deprecated and should no longer be used. Please use 'workspace.workspaceFolders' instead. More details: https://aka.ms/vscode-eliminating-rootpath
```