### PR TITLE
Enable prettier as default formatter

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+	"recommendations": [
+		"davidanson.vscode-markdownlint",
+		"esbenp.prettier-vscode"
+	]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true,
+    "[typescript]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    }
+}


### PR DESCRIPTION
Not sure what Visual Studio Code will do when prettier is not installed. Hopefully that's not a problem.