### PR TITLE
Implement "Playground"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,9 @@
 			"dev": true
 		},
 		"@types/vscode": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.20.0.tgz",
-			"integrity": "sha512-IeQ4kCfbRihpoeSWmC09bGjgdKXB5g09wWdPQcc2WHYjbpsf7p5U1F0bymEMKkyqnledI0LfMTgopwPwnrjTSg==",
+			"version": "1.41.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.41.0.tgz",
+			"integrity": "sha512-7SfeY5u9jgiELwxyLB3z7l6l/GbN9CqpCQGkcRlB7tKRFBxzbz2PoBfGrLxI1vRfUCIq5+hg5vtDHExwq5j3+A==",
 			"dev": true
 		},
 		"argparse": {

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
 			},
 			{
 				"command": "v.playground",
-				"title": "V: Upload and share current code to V playground"
+				"title": "V: Open current file on DevBits V playground"
 			}
 		]
 	},
@@ -130,7 +130,7 @@
 	},
 	"devDependencies": {
 		"@types/node": "^13.1.1",
-		"@types/vscode": "~1.20.0",
+		"@types/vscode": "^1.41.0",
 		"markdownlint-cli": "0.20.0",
 		"typescript": "~3.5.2"
 	},

--- a/src/client/commands.ts
+++ b/src/client/commands.ts
@@ -1,3 +1,4 @@
+import * as vscode from 'vscode';
 import { vrun } from './run';
 
 /**
@@ -40,4 +41,9 @@ export function testPackage() {}
 /**
  * Upload and share current code to V playground.
  */
-export function playground() {}
+export function playground() {
+	const fileContent = vscode.window.activeTextEditor.document.getText();
+	const buffer = new Buffer(fileContent).toString('base64');
+	const url = vscode.Uri.parse(`https://devbits.app/play?lang=v&code64=${buffer}`);
+	vscode.env.openExternal(url);
+}


### PR DESCRIPTION
### Implement Playground (`v.playground` command).

This feature will get the contents of the currently opened file and open it in [DevBit Playground](https://devbits.app/play). 
V Playground is currently unstable and there are no features available to allow us to pass the encoded code through the URL parameter. Thanks to [DevBit](https://devbits.app) that accepting my suggestion to add this feature.  🙂