### PR TITLE
Reduce list of activation events

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,15 +114,11 @@
 		]
 	},
 	"activationEvents": [
+		"workspaceContains:**/*.v",
 		"onLanguage:v",
-		"onCommand:v.run",
-		"onCommand:v.prod",
 		"onCommand:v.help",
 		"onCommand:v.ver",
-		"onCommand:v.path",
-		"onCommand:v.test.file",
-		"onCommand:v.test.package",
-		"onCommand:v.playground"
+		"onCommand:v.path"
 	],
 	"main": "./out/extension.js",
 	"dependencies": {


### PR DESCRIPTION
Added a new event to activate the extension, if a workspace contains V files.
Removed `onCommand:v.run`, `onCommand:v.test.file`, and `onCommand:v.playground` events: they are useless, as they require a V file opened.