### PR TITLE
Limit context of commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,13 +81,11 @@
 		"commands": [
 			{
 				"command": "v.run",
-				"title": "V: Run current file",
-				"enablement": "editorLangId == v"
+				"title": "V: Run current file"
 			},
 			{
 				"command": "v.prod",
-				"title": "V: Build an optimized executable from current file",
-				"enablement": "editorLangId == v"
+				"title": "V: Build an optimized executable from current file"
 			},
 			{
 				"command": "v.help",
@@ -103,19 +101,41 @@
 			},
 			{
 				"command": "v.test.file",
-				"title": "V: Test current file",
-				"enablement": "editorLangId == v"
+				"title": "V: Test current file"
 			},
 			{
 				"command": "v.test.package",
-				"title": "V: Test current package",
-				"enablement": "editorLangId == v"
+				"title": "V: Test current package"
 			},
 			{
 				"command": "v.playground",
 				"title": "V: Upload and share current code to V playground"
 			}
-		]
+		],
+		"menus": {
+			"commandPalette": [
+				{
+					"command": "v.run",
+					"when": "editorLangId == v"
+				},
+				{
+					"command": "v.prod",
+					"when": "editorLangId == v"
+				},
+				{
+					"command": "v.test.file",
+					"when": "editorLangId == v"
+				},
+				{
+					"command": "v.test.package",
+					"when": "editorLangId == v"
+				},
+				{
+					"command": "v.playground",
+					"when": "editorLangId == v"
+				}
+			]
+		  }
 	},
 	"activationEvents": [
 		"onLanguage:v",

--- a/package.json
+++ b/package.json
@@ -81,11 +81,13 @@
 		"commands": [
 			{
 				"command": "v.run",
-				"title": "V: Run current file"
+				"title": "V: Run current file",
+				"enablement": "editorLangId == v"
 			},
 			{
 				"command": "v.prod",
-				"title": "V: Build an optimized executable from current file"
+				"title": "V: Build an optimized executable from current file",
+				"enablement": "editorLangId == v"
 			},
 			{
 				"command": "v.help",
@@ -101,11 +103,13 @@
 			},
 			{
 				"command": "v.test.file",
-				"title": "V: Test current file"
+				"title": "V: Test current file",
+				"enablement": "editorLangId == v"
 			},
 			{
 				"command": "v.test.package",
-				"title": "V: Test current package"
+				"title": "V: Test current package",
+				"enablement": "editorLangId == v"
 			},
 			{
 				"command": "v.playground",


### PR DESCRIPTION
Use `when` property to hide commands in non-V context. See VS Code [docs][docs-when] for details.

<details>
  <summary>Previous description (left for history) (Click to expand)</summary>
Use `enablement` property to allow to execute commands for V files only.

According to VS Code [documentation][docs-enablement], `when` property is recommended over `enablement`, but `when` doesn't work for me: the commands are still visible in non-V context. On the other side, commands with `enablement` property added will be visible, but won't be executed in wrong context:
![image](https://user-images.githubusercontent.com/1119267/71689693-c2463b80-2db3-11ea-9f5a-6d0830ddccb3.png)
so, it's acceptable too, I think.

Probably, I was missing something when I added `when` property. Let me know if you know how to get it worked properly.

**Note**: the property for the `v.playground` command is added in another PR.
</details>

[docs-enablement]: https://code.visualstudio.com/api/extension-guides/command#enablement-of-commands
[docs-when]: https://code.visualstudio.com/api/extension-guides/command#controlling-when-a-command-shows-up-in-the-command-palette