### PR TITLE
Ignoring .markdownlint.json

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -7,3 +7,4 @@ images/
 **/tslint.json
 .gitignore
 tsconfig.json
+.markdownlint.json


### PR DESCRIPTION
Ignoring `.markdownlint.json` when packaging the extension.