### PR TITLE
Fix VSCode warning: Accessing a resource scoped configuration without providing a resource is not expected

### DIFF
--- a/src/client/commands.ts
+++ b/src/client/commands.ts
@@ -1,5 +1,5 @@
-import { window } from 'vscode';
-import { execVInTerminal, execV } from './exec';
+import { window } from "vscode";
+import { execVInTerminal, execV } from "./exec";
 
 /**
  * Run current file.
@@ -30,10 +30,10 @@ export function help() {}
  * Show version info.
  */
 export function ver() {
-	execV('-v', (err, stdout) => {
+	execV("-v", (err, stdout) => {
 		if (err) {
 			window.showErrorMessage(
-				'Unable to get the version number. Is V installed correctly?'
+				"Unable to get the version number. Is V installed correctly?"
 			);
 			return;
 		}

--- a/src/client/exec.ts
+++ b/src/client/exec.ts
@@ -1,12 +1,8 @@
-import { window, Terminal } from 'vscode';
-import { getVExecCommand, getCwd } from './utils';
-import { exec, ExecException } from 'child_process';
+import { window, Terminal } from "vscode";
+import { getVExecCommand, getCwd } from "./utils";
+import { exec, ExecException } from "child_process";
 
-type ExecCallback = (
-	error: ExecException | null,
-	stdout: string,
-	stderr: string
-) => void;
+type ExecCallback = (error: ExecException | null, stdout: string, stderr: string) => void;
 
 let vRunTerm: Terminal = null;
 
@@ -14,7 +10,7 @@ export function execVInTerminal(args: string) {
 	const cmd = getVExecCommand(args);
 
 	if (!vRunTerm) {
-		vRunTerm = window.createTerminal('V');
+		vRunTerm = window.createTerminal("V");
 	}
 	vRunTerm.show();
 	vRunTerm.sendText(cmd);
@@ -32,7 +28,7 @@ export function execV(args: string, callback: ExecCallback) {
 
 export function attachOnCloseTerminalListener() {
 	window.onDidCloseTerminal(term => {
-		if (term.name == 'V') {
+		if (term.name == "V") {
 			vRunTerm = null;
 		}
 	});

--- a/src/client/exec.ts
+++ b/src/client/exec.ts
@@ -1,4 +1,4 @@
-import { window, Terminal } from "vscode";
+import { window, Terminal, Disposable } from "vscode";
 import { getVExecCommand, getCwd } from "./utils";
 import { exec, ExecException } from "child_process";
 
@@ -9,9 +9,8 @@ let vRunTerm: Terminal = null;
 export function execVInTerminal(args: string) {
 	const cmd = getVExecCommand(args);
 
-	if (!vRunTerm) {
-		vRunTerm = window.createTerminal("V");
-	}
+	if (!vRunTerm) vRunTerm = window.createTerminal("V");
+
 	vRunTerm.show();
 	vRunTerm.sendText(cmd);
 }
@@ -26,10 +25,8 @@ export function execV(args: string, callback: ExecCallback) {
 	});
 }
 
-export function attachOnCloseTerminalListener() {
-	window.onDidCloseTerminal(term => {
-		if (term.name == "V") {
-			vRunTerm = null;
-		}
+export function attachOnCloseTerminalListener(): Disposable {
+	return window.onDidCloseTerminal(term => {
+		if (term.name == "V") vRunTerm = null;
 	});
 }

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -1,16 +1,16 @@
-import * as vscode from 'vscode';
-import * as commands from './commands';
-import { registerFormatter } from './format';
-import { attachOnCloseTerminalListener } from './exec';
+import * as vscode from "vscode";
+import * as commands from "./commands";
+import { registerFormatter } from "./format";
+import { attachOnCloseTerminalListener } from "./exec";
 
 const cmds = {
-	'v.run': commands.run,
-	'v.ver': commands.ver,
-	'v.help': commands.help,
-	'v.prod': commands.prod,
-	'v.test.file': commands.testFile,
-	'v.playground': commands.playground,
-	'v.test.package': commands.testPackage
+	"v.run": commands.run,
+	"v.ver": commands.ver,
+	"v.help": commands.help,
+	"v.prod": commands.prod,
+	"v.test.file": commands.testFile,
+	"v.playground": commands.playground,
+	"v.test.package": commands.testPackage
 };
 
 /**

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -25,8 +25,8 @@ export function activate(context: vscode.ExtensionContext) {
 		context.subscriptions.push(disposable);
 	}
 
-	registerFormatter();
-	attachOnCloseTerminalListener();
+	context.subscriptions.push(registerFormatter());
+	context.subscriptions.push(attachOnCloseTerminalListener());
 }
 
 /**

--- a/src/client/format.ts
+++ b/src/client/format.ts
@@ -3,7 +3,8 @@ import {
 	languages,
 	TextDocument,
 	TextEdit,
-	window
+	window,
+	Disposable
 } from "vscode";
 import { execV } from "./exec";
 import { fullDocumentRange, getVConfig } from "./utils";
@@ -24,11 +25,11 @@ function format(document: TextDocument): Promise<TextEdit[]> {
 	});
 }
 
-export function registerFormatter() {
+export function registerFormatter(): Disposable {
 	const provider: DocumentFormattingEditProvider = {
 		provideDocumentFormattingEdits(document: TextDocument): Thenable<TextEdit[]> {
 			return document.save().then(() => format(document));
 		}
 	};
-	languages.registerDocumentFormattingEditProvider("v", provider);
+	return languages.registerDocumentFormattingEditProvider("v", provider);
 }

--- a/src/client/format.ts
+++ b/src/client/format.ts
@@ -1,37 +1,34 @@
-import * as vscode from 'vscode';
-import { ExecException } from 'child_process';
-import { execV } from './exec';
-import { fullDocumentRange } from './utils';
+import {
+	DocumentFormattingEditProvider,
+	languages,
+	TextDocument,
+	TextEdit,
+	window
+} from "vscode";
+import { execV } from "./exec";
+import { fullDocumentRange, getVConfig } from "./utils";
 
-function format(document: vscode.TextDocument): Promise<vscode.TextEdit[]> {
+function format(document: TextDocument): Promise<TextEdit[]> {
 	return new Promise((resolve, reject) => {
-		const vfmtArgs = vscode.workspace.getConfiguration('v.format').get('args', '');
+		const vfmtArgs = getVConfig().get("format.args", "");
 		const args = `fmt ${vfmtArgs} ${document.fileName}`;
 
-		// Create new `callback` function for
-		function callback(error: ExecException, stdout: string, stderr: string) {
-			const isErr = error !== null;
-			if (isErr) {
+		execV(args, (err, stdout, stderr) => {
+			if (err) {
 				const errMessage = `Cannot format due to the following errors: ${stderr}`;
-				vscode.window.showErrorMessage(errMessage);
+				window.showErrorMessage(errMessage);
 				return reject(errMessage);
 			}
-			return resolve([
-				vscode.TextEdit.replace(fullDocumentRange(document), stdout)
-			]);
-		}
-
-		execV(args, callback);
+			return resolve([TextEdit.replace(fullDocumentRange(document), stdout)]);
+		});
 	});
 }
 
 export function registerFormatter() {
-	const provider: vscode.DocumentFormattingEditProvider = {
-		provideDocumentFormattingEdits(
-			document: vscode.TextDocument
-		): Thenable<vscode.TextEdit[]> {
+	const provider: DocumentFormattingEditProvider = {
+		provideDocumentFormattingEdits(document: TextDocument): Thenable<TextEdit[]> {
 			return document.save().then(() => format(document));
 		}
 	};
-	vscode.languages.registerDocumentFormattingEditProvider('v', provider);
+	languages.registerDocumentFormattingEditProvider("v", provider);
 }

--- a/src/client/utils.ts
+++ b/src/client/utils.ts
@@ -1,6 +1,13 @@
-import { Range, TextDocument, window, workspace } from 'vscode';
+import {
+	Range,
+	TextDocument,
+	workspace,
+	Uri,
+	WorkspaceConfiguration,
+	window
+} from "vscode";
 
-const defaultCommand = 'v';
+const defaultCommand = "v";
 
 export function fullDocumentRange(document: TextDocument): Range {
 	const lastLineId = document.lineCount - 1;
@@ -8,12 +15,22 @@ export function fullDocumentRange(document: TextDocument): Range {
 }
 
 export function getVExecCommand(args: string): string {
-	const config = workspace.getConfiguration('v');
-	const vPath = config.get('pathToExecutableFile', '') || defaultCommand;
+	const config = getVConfig();
+	const vPath = config.get("pathToExecutableFile", "") || defaultCommand;
 	return `${vPath} ${args}`;
+}
+
+export function getVConfig(): WorkspaceConfiguration {
+	const currentDoc = getCurrentDocument()
+	const uri = currentDoc ? currentDoc.uri : null
+	return workspace.getConfiguration("v", uri);
 }
 
 export function getCwd() {
 	const folder = workspace.workspaceFolders[0];
 	return folder.uri.fsPath;
+}
+
+export function getCurrentDocument(): TextDocument {
+	return window.activeTextEditor ? window.activeTextEditor.document : null;
 }


### PR DESCRIPTION
Fixed warning from VSCode when every time trying to execute one of the 'v' commands:

**"Warning: Accessing a resource scoped configuration without providing a resource is not expected."**

Full Log:
```log
[2020-01-09 03:55:56.898] [exthost] [warning] [0x9ef.vscode-vlang] Accessing a resource scoped configuration without providing a resource is not expected. To get the effective value for 'v.pathToExecutableFile', provide the URI of a resource or 'null' for any resource.
```