### PR TITLE
Fix type highlighting

### DIFF
--- a/syntaxes/v.tmLanguage.json
+++ b/syntaxes/v.tmLanguage.json
@@ -82,7 +82,7 @@
 			"include": "#strings"
 		},
 		{
-			"include": "types"
+			"include": "#types"
 		}
 	],
 	"repository": {
@@ -464,7 +464,7 @@
 									"include": "#generics"
 								},
 								{
-									"include": "types"
+									"include": "#types"
 								},
 								{
 									"include": "#punctuation"
@@ -524,7 +524,7 @@
 									"include": "#generics"
 								},
 								{
-									"include": "types"
+									"include": "#types"
 								},
 								{
 									"include": "#punctuation"
@@ -556,7 +556,7 @@
 									"include": "#generics"
 								},
 								{
-									"include": "types"
+									"include": "#types"
 								},
 								{
 									"include": "#punctuation"
@@ -745,7 +745,7 @@
 											"include": "#brackets"
 										},
 										{
-											"include": "types"
+											"include": "#types"
 										},
 										{
 											"match": "\\w+",
@@ -766,7 +766,7 @@
 							}
 						},
 						{
-							"include": "types"
+							"include": "#types"
 						},
 						{
 							"include": "$self"
@@ -889,7 +889,7 @@
 				}
 			]
 		},
-		"std-types": {
+		"types": {
 			"patterns": [
 				{
 					"name": "storage.type.numeric.v",


### PR DESCRIPTION
Include patterns properly.
Use correct pattern name for standart types.

Fix a regression added in c8dc0226b485ee7b5740d5de2117a6f408c42510.

<!--![image](https://user-images.githubusercontent.com/1119267/72204329-8849f900-3487-11ea-9b54-ed18f4b6ba1a.png)-->