### PR TITLE
Fix `struct` highlighting

### DIFF
--- a/syntaxes/v.tmLanguage.json
+++ b/syntaxes/v.tmLanguage.json
@@ -738,7 +738,7 @@
 				},
 				{
 					"name": "meta.definition.struct.v",
-					"match": "(?:(mut|pub(?:\\s+mut)?|__global)\\s+)?(struct)(?:\\s+([\\w.]+))?",
+					"match": "^\\s*(?:(mut|pub(?:\\s+mut)?|__global)\\s+)?(struct)(?:\\s+([\\w.]+))?",
 					"captures": {
 						"1": {
 							"name": "storage.modifier.$1.v"


### PR DESCRIPTION
Don't highlight `struct` word, if it's a part of a name.

Fixes #105.