### PR TITLE
Disable formatOnSave by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
 		"configurationDefaults": {
 			"[v]": {
 				"editor.insertSpaces": false,
-				"editor.formatOnSave": true,
+				"editor.formatOnSave": false,
 				"editor.codeActionsOnSave": {
 					"source.organizeImports": true
 				}


### PR DESCRIPTION
`vfmt` hasn't worked properly. so it's better to set it to false by default.