### PR TITLE
Add an option to enable/disable the linter

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,12 @@
 					"type": "string",
 					"default": "",
 					"description": "Path to V executable file"
+				},
+				"v.enableLinter": {
+					"scope": "language-overridable",
+					"type": "boolean",
+					"default": true,
+					"description": "Whether to enable the linter"
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
 					"description": "Path to V executable file"
 				},
 				"v.enableLinter": {
-					"scope": "language-overridable",
+					"scope": "resource",
 					"type": "boolean",
 					"default": true,
 					"description": "Whether to enable the linter"

--- a/src/client/extension.ts
+++ b/src/client/extension.ts
@@ -3,7 +3,7 @@ import * as commands from "./commands";
 import { registerFormatter } from "./format";
 import { attachOnCloseTerminalListener } from "./exec";
 import { lint, collection } from "./linter";
-import { clearTempFolder } from "./utils";
+import { clearTempFolder, getVConfig } from "./utils";
 
 const vLanguageId = "v";
 
@@ -24,23 +24,23 @@ const cmds = {
 export function activate(context: vscode.ExtensionContext) {
 	for (const cmd in cmds) {
 		const handler = cmds[cmd];
-
 		const disposable = vscode.commands.registerCommand(cmd, handler);
 		context.subscriptions.push(disposable);
 	}
 
-	context.subscriptions.push(
-		registerFormatter(),
-		attachOnCloseTerminalListener(),
-		vscode.window.onDidChangeVisibleTextEditors(didChangeVisibleTextEditors),
-		vscode.workspace.onDidSaveTextDocument(didSaveTextDocument),
-		vscode.workspace.onDidCloseTextDocument(didCloseTextDocument)
-	);
+	context.subscriptions.push(registerFormatter(), attachOnCloseTerminalListener());
 
-	// If there are V files open, do the lint immediately
-	if (vscode.window.activeTextEditor) {
-		if (vscode.window.activeTextEditor.document.languageId === vLanguageId) {
-			lint(vscode.window.activeTextEditor.document);
+	if (getVConfig().get("enableLinter")) {
+		context.subscriptions.push(
+			vscode.window.onDidChangeVisibleTextEditors(didChangeVisibleTextEditors),
+			vscode.workspace.onDidSaveTextDocument(didSaveTextDocument),
+			vscode.workspace.onDidCloseTextDocument(didCloseTextDocument)
+		);
+		// If there are V files open, do the lint immediately
+		if (vscode.window.activeTextEditor) {
+			if (vscode.window.activeTextEditor.document.languageId === vLanguageId) {
+				lint(vscode.window.activeTextEditor.document);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Closes #123 

**Note:** For better performance, the extension will only check when the activation event fired instead of checking that inside `lint()` function. 
So the user must restart their VSCode after changing the option.
