### PR TITLE
fix "V error: {file} doesn't exist": wrap fileName in quotes

### DIFF
--- a/src/client/commands.ts
+++ b/src/client/commands.ts
@@ -7,8 +7,9 @@ import { execVInTerminal, execV } from "./exec";
 export async function run() {
 	const document = window.activeTextEditor.document;
 	await document.save();
+	const filePath = `"${document.fileName}"`
 
-	execVInTerminal(["run", document.fileName]);
+	execVInTerminal(["run", filePath]);
 }
 
 /**
@@ -17,8 +18,9 @@ export async function run() {
 export async function prod() {
 	const document = window.activeTextEditor.document;
 	await document.save();
+	const filePath = `"${document.fileName}"`
 
-	execVInTerminal(["-prod", document.fileName]);
+	execVInTerminal(["-prod", filePath]);
 }
 
 /**


### PR DESCRIPTION
…in case the file's path includes spaces

This should fix #131 for Mac and Linux.