### PR TITLE
Use -version to get version number, close #133.

### DIFF
--- a/src/client/commands.ts
+++ b/src/client/commands.ts
@@ -30,7 +30,7 @@ export function help() {}
  * Show version info.
  */
 export function ver() {
-	execV(["-v"], (err, stdout) => {
+	execV(["-version"], (err, stdout) => {
 		if (err) {
 			window.showErrorMessage(
 				"Unable to get the version number. Is V installed correctly?"


### PR DESCRIPTION
When running `v -v`, the compiler prints the following warning:

>`v -v` now runs V with verbose mode set to level one which doesn't do anything.
>Did you mean `v -version` instead?

`v` flag is indeed used to set [verbose level](https://github.com/vlang/v/blob/aab31f4b352a70cc96731cd8eb00ca05b506ffc4/cmd/v/flag.v#L41):

```vlang
fn parse_flags(flag string, f mut flag.Instance, prefs mut flag.MainCmdPreferences) {
	match flag {
		'v' {
			f.is_equivalent_to(['v', 'vv', 'vvv', 'verbose'])
			prefs.verbosity = .level_one
		}
```

Although `v` is listed as a [synonym to `version`](https://github.com/vlang/v/blob/aab31f4b352a70cc96731cd8eb00ca05b506ffc4/cmd/v/flag.v#L80), it never matches:

```vlang
		'v', 'version' {
			f.is_equivalent_to(['v', 'version'])
			prefs.action = .version
		}
```

So let's use `-version` flag instead as suggested.