### PR TITLE
linter: fix column of error

### DIFF
--- a/src/client/linter.ts
+++ b/src/client/linter.ts
@@ -60,7 +60,7 @@ export function lint(document: TextDocument): boolean {
 				const { file, line, column, message } = parseError(output);
 				const fileuri = Uri.file(resolve(cwd, file));
 				const start = new Position(line - 1, column);
-				const end = new Position(line - 1, column + 1);
+				const end = new Position(line - 1, column);
 				const range = new Range(start, end);
 				const diagnostic = new Diagnostic(range, message, SEV_ERR);
 				diagnostic.source = "V";


### PR DESCRIPTION
the column was always wrong:
![image](https://user-images.githubusercontent.com/30751516/79344963-cba57f00-7f30-11ea-9e36-d1a0c80d0c65.png)
