### PR TITLE
format: fix error message file path

### DIFF
--- a/src/client/format.ts
+++ b/src/client/format.ts
@@ -21,7 +21,7 @@ function format(document: TextDocument): Promise<TextEdit[]> {
 			execV(args, (err, stdout, stderr) => {
 				unlink(tempFile, () => {
 					if (err) {
-						const errMessage = `Cannot format due to the following errors: ${stderr}`;
+						const errMessage = `Cannot format due to the following errors: ${stderr}`.replace(tempFile, document.fileName);
 						window.showErrorMessage(errMessage);
 						return reject(errMessage);
 					}


### PR DESCRIPTION
in the error message the path to the file is the name of the temp file instead of the original file. this PR fixes that.