### PR TITLE
linter: Ignores `Redefinition of function 'main'`

### DIFF
--- a/src/client/linter.ts
+++ b/src/client/linter.ts
@@ -28,10 +28,11 @@ export function lint(document: TextDocument): boolean {
 	const relativeFilename = relative(cwd, document.fileName);
 	const fileCount = readdirSync(foldername).filter((f) => f.endsWith(".v")).length;
 	const isMainModule = !!document.getText().match(/^\s*(module)+\s+main/);
-	const shared = isMainModule ? "" : "-shared";
+	const shared = !isMainModule ? "-shared" : "";
+	const haveMultipleMainFn = fileCount > 1 && isMainModule;
 
 	let target = foldername === cwd ? "." : relativeFoldername;
-	target = fileCount === 1 ? relativeFilename : target;
+	target = haveMultipleMainFn ? relativeFilename : target;
 	let status = true;
 
 	execV([shared, "-o", `${outDir}lint.c`, target], (err, stdout, stderr) => {


### PR DESCRIPTION
Fixes #142 
![linter-after-2020-05-08_21-47](https://user-images.githubusercontent.com/17797740/81413011-4f8d0880-9177-11ea-93c3-8776fa3d8144.png)
