### PR TITLE
linter: Using `./` for relative folder name of module & refactors

### DIFF
--- a/src/client/linter.ts
+++ b/src/client/linter.ts
@@ -1,6 +1,5 @@
 import {
 	TextDocument,
-	Position,
 	Range,
 	DiagnosticSeverity,
 	Diagnostic,
@@ -24,15 +23,13 @@ export function lint(document: TextDocument): boolean {
 
 	const cwd = workspaceFolder.uri.fsPath;
 	const foldername = dirname(document.fileName);
-	const relativeFoldername = relative(cwd, foldername);
-	const relativeFilename = relative(cwd, document.fileName);
 	const fileCount = readdirSync(foldername).filter((f) => f.endsWith(".v")).length;
 	const isMainModule = !!document.getText().match(/^\s*(module)+\s+main/);
 	const shared = !isMainModule ? "-shared" : "";
 	const haveMultipleMainFn = fileCount > 1 && isMainModule;
 
-	let target = foldername === cwd ? "." : relativeFoldername;
-	target = haveMultipleMainFn ? relativeFilename : target;
+	let target = foldername === cwd ? "." : `.${sep}${relative(cwd, foldername)}`;
+	target = haveMultipleMainFn ? relative(cwd, document.fileName) : target;
 	let status = true;
 
 	execV([shared, "-o", `${outDir}lint.c`, target], (err, stdout, stderr) => {
@@ -41,22 +38,20 @@ export function lint(document: TextDocument): boolean {
 			const output = stderr || stdout;
 			const lines: Array<string> = output.split("\n");
 
-			lines.forEach((line) => {
+			for (const line of lines) {
 				const cols = line.split(":");
 				const isInfo = cols.length >= 5;
 				const isError = isInfo && trimBoth(cols[3]) === "error";
 				const isWarning = isInfo && trimBoth(cols[3]) === "warning";
 
-				if (isInfo && (isError || isWarning)) {
+				if (isError || isWarning) {
 					const file = cols[0];
 					const lineNum = parseInt(cols[1]);
 					const colNum = parseInt(cols[2]);
 					const message = cols.splice(4, cols.length - 1).join("");
 
 					const fileURI = Uri.file(resolve(cwd, file));
-					const start = new Position(lineNum - 1, colNum);
-					const end = new Position(lineNum - 1, colNum);
-					const range = new Range(start, end);
+					const range = new Range(lineNum - 1, colNum, lineNum - 1, colNum);
 					const diagnostic = new Diagnostic(
 						range,
 						message,
@@ -65,7 +60,7 @@ export function lint(document: TextDocument): boolean {
 					diagnostic.source = "V";
 					collection.set(fileURI, [...collection.get(fileURI), diagnostic]);
 				}
-			});
+			}
 			status = false;
 		} else {
 			collection.delete(document.uri);


### PR DESCRIPTION
The old linter trying will using `folder_name` to pass on V compiler, so V compiler got panic and can't display warnings or errors. To fix it, we should use `./folder_name` instead.

#### BEFORE
![before-2020-05-09_05-37](https://user-images.githubusercontent.com/17797740/81451953-38223f80-91b8-11ea-944b-88f5c673a833.png)
The command that linter use:
![2020-05-09_05-48](https://user-images.githubusercontent.com/17797740/81452182-c991b180-91b8-11ea-8423-5d1f523a19c8.png)

--------------------------------------------------------

#### AFTER
![after-2020-05-09_05-37](https://user-images.githubusercontent.com/17797740/81451988-483a1f00-91b8-11ea-8f91-d63902dea296.png)
The command that linter use:
![2020-05-09_05-50](https://user-images.githubusercontent.com/17797740/81452292-12496a80-91b9-11ea-94cb-d5aaa204dea6.png)


Also, I do some refactor to improve performance.