### PR TITLE
linter: Improve multiple main module checking

### DIFF
--- a/src/client/linter.ts
+++ b/src/client/linter.ts
@@ -38,7 +38,8 @@ export function lint(document: TextDocument): boolean {
 		vFiles.forEach(async (f) => {
 			f = resolve(foldername, f);
 			const fDocument = await workspace.openTextDocument(f);
-			filesAreMainModule = checkMainModule(fDocument.getText());
+			filesAreMainModule =
+				checkMainModule(fDocument.getText()) || checkMainFn(fDocument.getText());
 		});
 		haveMultipleMainFn = filesAreMainModule;
 	}

--- a/src/client/linter.ts
+++ b/src/client/linter.ts
@@ -6,7 +6,6 @@ import {
 	languages,
 	Uri,
 	workspace,
-	window,
 } from "vscode";
 import { tmpdir } from "os";
 import { sep } from "path";

--- a/src/client/linter.ts
+++ b/src/client/linter.ts
@@ -5,6 +5,8 @@ import {
 	Diagnostic,
 	languages,
 	Uri,
+	workspace,
+	window,
 } from "vscode";
 import { tmpdir } from "os";
 import { sep } from "path";
@@ -15,6 +17,8 @@ import { readdirSync } from "fs";
 
 const outDir = `${tmpdir()}${sep}vscode_vlang${sep}`;
 export const collection = languages.createDiagnosticCollection("V");
+const checkMainModule = (text: string) => !!text.match(/^\s*(module)+\s+main/);
+const checkMainFn = (text: string) => !!text.match(/^\s*(fn)+\s+main/);
 
 export function lint(document: TextDocument): boolean {
 	const workspaceFolder = getWorkspaceFolder(document.uri);
@@ -23,12 +27,22 @@ export function lint(document: TextDocument): boolean {
 
 	const cwd = workspaceFolder.uri.fsPath;
 	const foldername = dirname(document.fileName);
-	const fileCount = readdirSync(foldername).filter((f) => f.endsWith(".v")).length;
+	const vFiles = readdirSync(foldername).filter((f) => f.endsWith(".v"));
+	const fileCount = vFiles.length;
 	const isMainModule =
-		!!document.getText().match(/^\s*(module)+\s+main/) ||
-		!!document.getText().match(/^\s*(fn)+\s+main/);
+		checkMainModule(document.getText()) || checkMainFn(document.getText());
 	const shared = !isMainModule ? "-shared" : "";
-	const haveMultipleMainFn = fileCount > 1 && isMainModule;
+	let haveMultipleMainFn = fileCount > 1 && isMainModule;
+
+	if (haveMultipleMainFn) {
+		let filesAreMainModule = false;
+		vFiles.forEach(async (f) => {
+			f = resolve(foldername, f);
+			const fDocument = await workspace.openTextDocument(f);
+			filesAreMainModule = checkMainModule(fDocument.getText());
+		});
+		haveMultipleMainFn = filesAreMainModule;
+	}
 
 	let target = foldername === cwd ? "." : `.${sep}${relative(cwd, foldername)}`;
 	target = haveMultipleMainFn ? relative(cwd, document.fileName) : target;


### PR DESCRIPTION
Improve checking for main modules by checking one by one instead.

#### BEFORE 
![2020-05-11_04-08](https://user-images.githubusercontent.com/17797740/81509475-890f7080-933d-11ea-8d7a-27bde50698e1.png)

Both `vls.v` & `initialize.v` are main module, but we got that error.  That because of the linter execute this command: `v ./vls.v` or `v ./initialize.v` which is invalid. The linter must execute this command instead: `v .`.

#### AFTER
![2020-05-11_04-10](https://user-images.githubusercontent.com/17797740/81509481-9593c900-933d-11ea-8849-16aecbcabbfd.png)

