### PR TITLE
fix: improve syntax highlighting for string interpolation

### DIFF
--- a/syntaxes/tests/string.v
+++ b/syntaxes/tests/string.v
@@ -2,8 +2,10 @@
 _ := 'test'
 //    ^^^^ string.quoted.v
 a := 1
+b := 2
 _ := '$a'
-//    ^^ variable.other.interpolated.v
+//    ^ punctuation.definition.template-expression.begin.v
+//     ^ variable.other.interpolated.v
 _ := '\\'
 //    ^^ constant.character.escape.v
 _ := c'test'
@@ -17,5 +19,11 @@ _ := r"\"
 //   ^ storage.type.string.v
 //    ^^^ string.quoted.raw.v
 _ := r'$a'
-//     ^^ variable.other.interpolated.v
+//   ^ storage.type.string.v
+//    ^^^ string.quoted.raw.v
+_ := '${a + b}'
+//    ^^ punctuation.definition.template-expression.begin.v
+//        ^ keyword.operator.arithmetic.v
+//          ^ variable.other.v
+//           ^ punctuation.definition.template-expression.end.v
 

--- a/syntaxes/tests/string.v
+++ b/syntaxes/tests/string.v
@@ -4,8 +4,7 @@ _ := 'test'
 a := 1
 b := 2
 _ := '$a'
-//    ^ punctuation.definition.template-expression.begin.v
-//     ^ variable.other.interpolated.v
+//    ^^ string.quoted.v
 _ := '\\'
 //    ^^ constant.character.escape.v
 _ := c'test'

--- a/syntaxes/v.tmLanguage.json
+++ b/syntaxes/v.tmLanguage.json
@@ -883,9 +883,6 @@
 					"name": "string.quoted.raw.v",
 					"patterns": [
 						{
-							"include": "#string-interpolation"
-						},
-						{
 							"include": "#string-placeholder"
 						}
 					]
@@ -900,9 +897,6 @@
 					"end": "\"",
 					"name": "string.quoted.raw.v",
 					"patterns": [
-						{
-							"include": "#string-interpolation"
-						},
 						{
 							"include": "#string-placeholder"
 						}
@@ -965,22 +959,68 @@
 			]
 		},
 		"string-interpolation": {
-			"name": "meta.string.interpolation.v",
-			"match": "(\\$([\\w.]+|\\{.*?\\}))",
-			"captures": {
-				"1": {
+			"patterns": [
+				{
+					"name": "meta.string.interpolation.v",
+					"begin": "(\\$\\{)",
+					"beginCaptures": {
+						"1": {
+							"name": "punctuation.definition.template-expression.begin.v"
+						}
+					},
+					"end": "(\\})",
+					"endCaptures": {
+						"1": {
+							"name": "punctuation.definition.template-expression.end.v"
+						}
+					},
 					"patterns": [
 						{
-							"name": "invalid.illegal.v",
-							"match": "\\$\\d[\\.\\w]+"
+							"include": "#operators"
 						},
 						{
-							"name": "variable.other.interpolated.v",
-							"match": "\\$([\\.\\w]+|\\{.*?\\})"
+							"include": "#numbers"
+						},
+						{
+							"include": "#function-exist"
+						},
+						{
+							"include": "#types"
+						},
+						{
+							"include": "#constants"
+						},
+						{
+							"match": "\\w+",
+							"name": "variable.other.v"
 						}
 					]
+				},
+				{
+					"name": "meta.string.interpolation.v",
+					"match": "(\\$)(\\d[\\.\\w]+)",
+					"captures": {
+						"1": {
+							"name": "punctuation.definition.template-expression.begin.v"
+						},
+						"2": {
+							"name": "invalid.illegal.v"
+						}
+					}
+				},
+				{
+					"name": "meta.string.interpolation.v",
+					"match": "(\\$)([\\w.]+)",
+					"captures": {
+						"1": {
+							"name": "punctuation.definition.template-expression.begin.v"
+						},
+						"2": {
+							"name": "variable.other.interpolated.v"
+						}
+					}
 				}
-			}
+			]
 		},
 		"string-placeholder": {
 			"match": "%(\\[\\d+\\])?([\\+#\\-0\\x20]{,2}((\\d+|\\*)?(\\.?(\\d+|\\*|(\\[\\d+\\])\\*?)?(\\[\\d+\\])?)?))?[vT%tbcdoqxXUbeEfFgGsp]",

--- a/syntaxes/v.tmLanguage.json
+++ b/syntaxes/v.tmLanguage.json
@@ -995,30 +995,6 @@
 							"name": "variable.other.v"
 						}
 					]
-				},
-				{
-					"name": "meta.string.interpolation.v",
-					"match": "(\\$)(\\d[\\.\\w]+)",
-					"captures": {
-						"1": {
-							"name": "punctuation.definition.template-expression.begin.v"
-						},
-						"2": {
-							"name": "invalid.illegal.v"
-						}
-					}
-				},
-				{
-					"name": "meta.string.interpolation.v",
-					"match": "(\\$)([\\w.]+)",
-					"captures": {
-						"1": {
-							"name": "punctuation.definition.template-expression.begin.v"
-						},
-						"2": {
-							"name": "variable.other.interpolated.v"
-						}
-					}
 				}
 			]
 		},


### PR DESCRIPTION
Before

<img width="262" height="137" alt="Screenshot 2026-03-31 at 10 15 41 PM" src="https://github.com/user-attachments/assets/1e7868bd-5240-434c-bb3b-2d8f446b55e5" />

After

<img width="276" height="142" alt="image" src="https://github.com/user-attachments/assets/1d3c33ed-00ac-4bf1-b4c1-ba4ab763daac" />
